### PR TITLE
A j footer source repo

### DIFF
--- a/frontend/src/fixtures/systemInfoFixtures.js
+++ b/frontend/src/fixtures/systemInfoFixtures.js
@@ -3,6 +3,7 @@ const systemInfoFixtures = {
     {
         "springH2ConsoleEnabled": true,
         "showSwaggerUILink": true,
+        "sourceRepoUrl": "https://github.com/ucsb-cs156-s22/s22-4pm-courses",
         "startQtrYYYYQ": "20084",
         "endQtrYYYYQ": "20222"
     },
@@ -10,6 +11,7 @@ const systemInfoFixtures = {
     {
         "springH2ConsoleEnabled": false,
         "showSwaggerUILink": false,
+        "sourceRepoUrl": "https://github.com/ucsb-cs156-s22/s22-4pm-courses",
         "startQtrYYYYQ": "20084",
         "endQtrYYYYQ": "20222"
     }

--- a/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
@@ -17,7 +17,6 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
   // Stryker disable OptionalChaining
   const startQtr = systemInfo?.startQtrYYYYQ || "20211";
   const endQtr = systemInfo?.endQtrYYYYQ || "20214";
-  // const sourceRepoUrl = systemInfo?.sourceRepoUrl || "https://github.com/ucsb-cs156-s22/s22-4pm-courses";
   // Stryker enable OptionalChaining
 
   const quarters = quarterRange(startQtr, endQtr);

--- a/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
@@ -17,6 +17,7 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
   // Stryker disable OptionalChaining
   const startQtr = systemInfo?.startQtrYYYYQ || "20211";
   const endQtr = systemInfo?.endQtrYYYYQ || "20214";
+  // const sourceRepoUrl = systemInfo?.sourceRepoUrl || "https://github.com/ucsb-cs156-s22/s22-4pm-courses";
   // Stryker enable OptionalChaining
 
   const quarters = quarterRange(startQtr, endQtr);

--- a/frontend/src/main/components/Nav/Footer.js
+++ b/frontend/src/main/components/Nav/Footer.js
@@ -2,7 +2,7 @@ import { Container } from "react-bootstrap";
 
 export const space=" ";
 
-export default function Footer() {
+export default function Footer( {systemInfo}) {
   return (
     <footer className="bg-light pt-3 pt-md-4 pb-4 pb-md-5">
       <Container>
@@ -26,7 +26,7 @@ export default function Footer() {
       {space}
       <a
         data-testid="footer-source-code-link"
-        href="https://github.com/ucsb-cs156-s22/s22-4pm-courses"
+        href = {systemInfo.sourceRepoUrl}
         target="_blank"
         rel="noopener noreferrer"
       >

--- a/frontend/src/main/layouts/BasicLayout/BasicLayout.js
+++ b/frontend/src/main/layouts/BasicLayout/BasicLayout.js
@@ -17,7 +17,7 @@ export default function BasicLayout({ children }) {
       <Container expand="xl" className="pt-4 flex-grow-1">
         {children}
       </Container>
-      <Footer />
+      <Footer systemInfo={systemInfo}/>
     </div>
   );
 }

--- a/frontend/src/main/utils/systemInfo.js
+++ b/frontend/src/main/utils/systemInfo.js
@@ -12,7 +12,7 @@ export function useSystemInfo() {
       return {  
         springH2ConsoleEnabled: false,
         showSwaggerUILink: false,
-        sourceRepoUrl:"https://github.com/ucsb-cs156-s22/s22-4pm-courses",
+        sourceRepoUrl:"https://github.com/ucsb-cs156/proj-courses",
         startQtrYYYYQ: "20221",
         endQtrYYYYQ: "20222"  
       };
@@ -22,7 +22,7 @@ export function useSystemInfo() {
       initialData:true, 
       springH2ConsoleEnabled: false,
       showSwaggerUILink: false,
-      sourceRepoUrl:"https://github.com/ucsb-cs156-s22/s22-4pm-courses",
+      sourceRepoUrl:"https://github.com/ucsb-cs156/proj-courses",
       startQtrYYYYQ: "20221",
       endQtrYYYYQ: "20222"  
     }

--- a/frontend/src/main/utils/systemInfo.js
+++ b/frontend/src/main/utils/systemInfo.js
@@ -12,6 +12,7 @@ export function useSystemInfo() {
       return {  
         springH2ConsoleEnabled: false,
         showSwaggerUILink: false,
+        sourceRepoUrl:"https://github.com/ucsb-cs156-s22/s22-4pm-courses",
         startQtrYYYYQ: "20221",
         endQtrYYYYQ: "20222"  
       };
@@ -21,6 +22,7 @@ export function useSystemInfo() {
       initialData:true, 
       springH2ConsoleEnabled: false,
       showSwaggerUILink: false,
+      sourceRepoUrl:"https://github.com/ucsb-cs156-s22/s22-4pm-courses",
       startQtrYYYYQ: "20221",
       endQtrYYYYQ: "20222"  
     }

--- a/frontend/src/stories/layouts/BasicLayout/Footer.stories.js
+++ b/frontend/src/stories/layouts/BasicLayout/Footer.stories.js
@@ -2,6 +2,7 @@
 import React from 'react';
 
 import Footer from "main/components/Nav/Footer";
+import { systemInfoFixtures } from 'fixtures/systemInfoFixtures';
 
 export default {
     title: 'layouts/BasicLayout/Footer',
@@ -9,10 +10,12 @@ export default {
 };
 
 
-const Template = () => {
+const Template = (args) => {
     return (
-        <Footer />
+        <Footer {...args}/>
     )
 };
 
 export const Default = Template.bind({});
+Default.args = {systemInfo: systemInfoFixtures.showingNeither}
+

--- a/frontend/src/tests/components/Nav/Footer.test.js
+++ b/frontend/src/tests/components/Nav/Footer.test.js
@@ -26,7 +26,7 @@ describe("Footer tests", () => {
         );
         expect(screen.getByTestId("footer-source-code-link")).toHaveAttribute(
           "href",
-          "https://github.com/ucsb-cs156-s22/s22-4pm-courses"
+          "https://github.com/ucsb-cs156/proj-courses"
         );
 
         expect(screen.getByTestId("footer-sticker-link")).toHaveAttribute(

--- a/frontend/src/tests/components/Nav/Footer.test.js
+++ b/frontend/src/tests/components/Nav/Footer.test.js
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import Footer, {space} from "main/components/Nav/Footer";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 
 describe("Footer tests", () => {
     test("space stands for a space", () => {
@@ -8,11 +9,13 @@ describe("Footer tests", () => {
     
     
       test("renders without crashing", () => {
-        render(<Footer />);
+        const systemInfo = systemInfoFixtures.showingBoth;
+        render(<Footer systemInfo={systemInfo}  />);
       });
     
       test("Links are correct", async () => {
-        render(<Footer />)
+        const SysInfo = systemInfoFixtures.showingBoth;
+        render(<Footer systemInfo={SysInfo} />)
         expect(screen.getByTestId("footer-class-website-link")).toHaveAttribute(
           "href",
           "https://ucsb-cs156.github.io"

--- a/frontend/src/tests/components/Nav/Footer.test.js
+++ b/frontend/src/tests/components/Nav/Footer.test.js
@@ -26,7 +26,7 @@ describe("Footer tests", () => {
         );
         expect(screen.getByTestId("footer-source-code-link")).toHaveAttribute(
           "href",
-          "https://github.com/ucsb-cs156/proj-courses"
+          SysInfo.sourceRepoUrl
         );
 
         expect(screen.getByTestId("footer-sticker-link")).toHaveAttribute(

--- a/frontend/src/tests/utils/systemInfo.test.js
+++ b/frontend/src/tests/utils/systemInfo.test.js
@@ -33,7 +33,7 @@ describe("utils/systemInfo tests", () => {
                 initialData:true,   
                 springH2ConsoleEnabled: false,
                 showSwaggerUILink: false,
-                sourceRepoUrl: "https://github.com/ucsb-cs156-s22/s22-4pm-courses",
+                sourceRepoUrl: "https://github.com/ucsb-cs156/proj-courses",
                 startQtrYYYYQ: "20221",
                 endQtrYYYYQ: "20222"  
             });
@@ -95,7 +95,7 @@ describe("utils/systemInfo tests", () => {
             expect(result.current.data).toEqual({  
                 springH2ConsoleEnabled: false,
                 showSwaggerUILink: false,
-                sourceRepoUrl : "https://github.com/ucsb-cs156-s22/s22-4pm-courses",
+                sourceRepoUrl : "https://github.com/ucsb-cs156/proj-courses",
                 startQtrYYYYQ: "20221",
                 endQtrYYYYQ: "20222"
             });

--- a/frontend/src/tests/utils/systemInfo.test.js
+++ b/frontend/src/tests/utils/systemInfo.test.js
@@ -33,6 +33,7 @@ describe("utils/systemInfo tests", () => {
                 initialData:true,   
                 springH2ConsoleEnabled: false,
                 showSwaggerUILink: false,
+                sourceRepoUrl: "https://github.com/ucsb-cs156-s22/s22-4pm-courses",
                 startQtrYYYYQ: "20221",
                 endQtrYYYYQ: "20222"  
             });
@@ -94,6 +95,7 @@ describe("utils/systemInfo tests", () => {
             expect(result.current.data).toEqual({  
                 springH2ConsoleEnabled: false,
                 showSwaggerUILink: false,
+                sourceRepoUrl : "https://github.com/ucsb-cs156-s22/s22-4pm-courses",
                 startQtrYYYYQ: "20221",
                 endQtrYYYYQ: "20222"
             });

--- a/src/main/java/edu/ucsb/cs156/courses/models/SystemInfo.java
+++ b/src/main/java/edu/ucsb/cs156/courses/models/SystemInfo.java
@@ -17,6 +17,7 @@ import lombok.AccessLevel;
 public class SystemInfo {
   private Boolean springH2ConsoleEnabled;
   private Boolean showSwaggerUILink;
+  private String SourceRepoUrl;
   private String startQtrYYYYQ;
   private String endQtrYYYYQ;
 }

--- a/src/main/java/edu/ucsb/cs156/courses/models/SystemInfo.java
+++ b/src/main/java/edu/ucsb/cs156/courses/models/SystemInfo.java
@@ -17,7 +17,7 @@ import lombok.AccessLevel;
 public class SystemInfo {
   private Boolean springH2ConsoleEnabled;
   private Boolean showSwaggerUILink;
-  private String SourceRepoUrl;
+  private String sourceRepoUrl;
   private String startQtrYYYYQ;
   private String endQtrYYYYQ;
 }

--- a/src/main/java/edu/ucsb/cs156/courses/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/SystemInfoServiceImpl.java
@@ -21,6 +21,9 @@ public class SystemInfoServiceImpl extends SystemInfoService {
   @Value("${app.showSwaggerUILink:false}")
   private boolean showSwaggerUILink;
 
+  @Value("${app.sourceRepoUrl:https://github.com/ucsb-cs156-s22/s22-4pm-courses}")
+  private String sourceRepoUrl;
+
   @Value("${app.startQtrYYYYQ:20221}")
   private String startQtrYYYYQ;
 
@@ -31,6 +34,7 @@ public class SystemInfoServiceImpl extends SystemInfoService {
     SystemInfo si = SystemInfo.builder()
     .springH2ConsoleEnabled(this.springH2ConsoleEnabled)
     .showSwaggerUILink(this.showSwaggerUILink)
+    .sourceRepoUrl(this.sourceRepoUrl)
     .startQtrYYYYQ(this.startQtrYYYYQ)
     .endQtrYYYYQ(this.endQtrYYYYQ)
     .build();

--- a/src/main/java/edu/ucsb/cs156/courses/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/SystemInfoServiceImpl.java
@@ -21,7 +21,7 @@ public class SystemInfoServiceImpl extends SystemInfoService {
   @Value("${app.showSwaggerUILink:false}")
   private boolean showSwaggerUILink;
 
-  @Value("${app.sourceRepoUrl:https://github.com/ucsb-cs156-s22/s22-4pm-courses}")
+  @Value("${app.sourceRepoUrl:https://github.com/ucsb-cs156/proj-courses}")
   private String sourceRepoUrl;
 
   @Value("${app.startQtrYYYYQ:20221}")

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -28,5 +28,5 @@ spring.mvc.format.date-time=iso
 
 app.startQtrYYYYQ=${START_QTR:${env.START_QTR:20221}}
 app.endQtrYYYYQ=${END_QTR:${env.END_QTR:20222}}
-app.sourceRepoUrl=${SRC_REPO:${env.SRC_REPO:https://github.com/ucsb-cs156/proj-courses}}
+app.sourceRepoUrl=${SOURCE_REPO:${env.SOURCE_REPO:https://github.com/ucsb-cs156/proj-courses}}
 app.ucsb.api.consumer_key=${UCSB_API_KEY:${env.UCSB_API_KEY:see-instructions-in-readme}}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -28,5 +28,5 @@ spring.mvc.format.date-time=iso
 
 app.startQtrYYYYQ=${START_QTR:${env.START_QTR:20221}}
 app.endQtrYYYYQ=${END_QTR:${env.END_QTR:20222}}
-
+app.sourceRepoUrl=${SRC_REPO:${env.SRC_REPO:https://github.com/ucsb-cs156/proj-courses}}
 app.ucsb.api.consumer_key=${UCSB_API_KEY:${env.UCSB_API_KEY:see-instructions-in-readme}}

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/SystemInfoControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/SystemInfoControllerTests.java
@@ -33,6 +33,7 @@ public class SystemInfoControllerTests extends ControllerTestCase {
         .builder()
         .showSwaggerUILink(true)
         .springH2ConsoleEnabled(true)
+        .sourceRepoUrl("https://github.com/ucsb-cs156-s22/s22-4pm-courses")
         .startQtrYYYYQ("20221")
         .endQtrYYYYQ("20222")
         .build();
@@ -59,6 +60,7 @@ public class SystemInfoControllerTests extends ControllerTestCase {
         .builder()
         .showSwaggerUILink(true)
         .springH2ConsoleEnabled(true)
+        .sourceRepoUrl("https://github.com/ucsb-cs156-s22/s22-4pm-courses")
         .startQtrYYYYQ("20221")
         .endQtrYYYYQ("20222")
         .build();
@@ -84,6 +86,7 @@ public class SystemInfoControllerTests extends ControllerTestCase {
         .builder()
         .showSwaggerUILink(true)
         .springH2ConsoleEnabled(true)
+        .sourceRepoUrl("https://github.com/ucsb-cs156-s22/s22-4pm-courses")
         .startQtrYYYYQ("20221")
         .endQtrYYYYQ("20222")
         .build();


### PR DESCRIPTION
Abel & Junhwan Lee
- [x] Change the footer component so that it gets the value of the URL for the source repo from /api/systeminfo.
<img width="1389" alt="Screenshot 2022-11-18 at 9 05 32 PM" src="https://user-images.githubusercontent.com/69553149/202835238-7aeb9663-c91a-427f-adcb-5ec20d55f7cd.png">

- [x] Modified tests on both backend and frontend.
- [x] Modified the fixtures for systemInfo.
- [x] Modified storybook to reflect the changes in the footer.
<img width="1440" alt="Screenshot 2022-11-18 at 9 04 53 PM" src="https://user-images.githubusercontent.com/69553149/202835216-6ee0fa0c-ec56-43f7-ac3a-11975375e212.png">

- [x] Added String sourceRepo to the SystemInfo class
- [x] Added initialization of this value from a property called app.sourceRepo in src/main/resources/application.properties.
- [x] Allowed that property to be overridden by an environment variable SOURCE_REPO 
- [x] Made sure that the correct value is exposed by looking at the /api/systemInfo endpoint in Swagger.
<img width="1388" alt="Screenshot 2022-11-22 at 6 14 21 PM" src="https://user-images.githubusercontent.com/69553149/203457169-1e327722-9591-4774-9355-2c6d622f3d32.png">
