### PR TITLE
MN & EE - Implement 15 character limit for Personal Schedule names

### DIFF
--- a/frontend/src/main/components/PersonalSchedules/PersonalScheduleForm.js
+++ b/frontend/src/main/components/PersonalSchedules/PersonalScheduleForm.js
@@ -59,7 +59,7 @@ function PersonalScheduleForm({ initialPersonalSchedule, submitAction, buttonLab
                     type="text"
                     isInvalid={Boolean(errors.name)}
                     {...register("name", {
-                        required: "Name is required."
+                        required: "Name of less than 15 characters is required."
                     })}
                 />
                 <Form.Control.Feedback type="invalid">

--- a/frontend/src/main/components/PersonalSchedules/PersonalScheduleForm.js
+++ b/frontend/src/main/components/PersonalSchedules/PersonalScheduleForm.js
@@ -59,7 +59,7 @@ function PersonalScheduleForm({ initialPersonalSchedule, submitAction, buttonLab
                     type="text"
                     isInvalid={Boolean(errors.name)}
                     {...register("name", {
-                        required: "Name of less than 15 characters is required."
+                        required: "Name of up to 15 characters is required."
                     })}
                 />
                 <Form.Control.Feedback type="invalid">

--- a/frontend/src/tests/components/PersonalSchedules/PersonalScheduleForm.test.js
+++ b/frontend/src/tests/components/PersonalSchedules/PersonalScheduleForm.test.js
@@ -76,7 +76,7 @@ describe("PersonalScheduleForm tests", () => {
 
         fireEvent.click(submitButton);
 
-        expect(await screen.findByText(/Name of less than 15 characters is required./)).toBeInTheDocument();
+        expect(await screen.findByText(/Name of up to 15 characters is required./)).toBeInTheDocument();
         expect(screen.getByText(/Description is required./)).toBeInTheDocument();
     });
 

--- a/frontend/src/tests/components/PersonalSchedules/PersonalScheduleForm.test.js
+++ b/frontend/src/tests/components/PersonalSchedules/PersonalScheduleForm.test.js
@@ -76,7 +76,7 @@ describe("PersonalScheduleForm tests", () => {
 
         fireEvent.click(submitButton);
 
-        expect(await screen.findByText(/Name is required./)).toBeInTheDocument();
+        expect(await screen.findByText(/Name of less than 15 characters is required./)).toBeInTheDocument();
         expect(screen.getByText(/Description is required./)).toBeInTheDocument();
     });
 

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/ApiController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/ApiController.java
@@ -2,6 +2,7 @@ package edu.ucsb.cs156.courses.controllers;
 
 import edu.ucsb.cs156.courses.errors.EntityNotFoundException;
 import edu.ucsb.cs156.courses.errors.BadEnrollCdException;
+import edu.ucsb.cs156.courses.errors.CharLimitExceededException;
 import net.bytebuddy.implementation.bytecode.Throw;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -27,7 +28,7 @@ public abstract class ApiController {
     return Map.of("message", message);
   }
 
-  @ExceptionHandler({ EntityNotFoundException.class, BadEnrollCdException.class })
+  @ExceptionHandler({ EntityNotFoundException.class, BadEnrollCdException.class, CharLimitExceededException.class })
   @ResponseStatus(HttpStatus.NOT_FOUND)
   public Object handleGenericException(Throwable e) {
     return Map.of(

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesController.java
@@ -89,7 +89,7 @@ public class PersonalSchedulesController extends ApiController {
         CurrentUser currentUser = getCurrentUser();
         log.info("currentUser={}", currentUser);
 
-        if (name.length() > 15) {
+        if (name.length() >= 15) {
           throw new CharLimitExceededException(name);
         }
 

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesController.java
@@ -89,7 +89,7 @@ public class PersonalSchedulesController extends ApiController {
         CurrentUser currentUser = getCurrentUser();
         log.info("currentUser={}", currentUser);
 
-        if (name.length() >= 15) {
+        if (name.length() <= 15) {
           throw new CharLimitExceededException(name);
         }
 

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesController.java
@@ -89,7 +89,7 @@ public class PersonalSchedulesController extends ApiController {
         CurrentUser currentUser = getCurrentUser();
         log.info("currentUser={}", currentUser);
 
-        if (name.length() >= 15) {
+        if (name.length() > 15) {
           throw new CharLimitExceededException(name);
         }
 

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesController.java
@@ -2,6 +2,7 @@ package edu.ucsb.cs156.courses.controllers;
 
 import edu.ucsb.cs156.courses.entities.PersonalSchedule;
 import edu.ucsb.cs156.courses.entities.User;
+import edu.ucsb.cs156.courses.errors.CharLimitExceededException;
 import edu.ucsb.cs156.courses.errors.EntityNotFoundException;
 import edu.ucsb.cs156.courses.models.CurrentUser;
 import edu.ucsb.cs156.courses.repositories.PersonalScheduleRepository;
@@ -87,6 +88,10 @@ public class PersonalSchedulesController extends ApiController {
             @ApiParam("quarter") @RequestParam String quarter) {
         CurrentUser currentUser = getCurrentUser();
         log.info("currentUser={}", currentUser);
+
+        if (name.length() > 15) {
+          throw new CharLimitExceededException(name);
+        }
 
         PersonalSchedule personalschedule = new PersonalSchedule();
         personalschedule.setUser(currentUser.getUser());

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesController.java
@@ -89,7 +89,7 @@ public class PersonalSchedulesController extends ApiController {
         CurrentUser currentUser = getCurrentUser();
         log.info("currentUser={}", currentUser);
 
-        if (name.length() <= 15) {
+        if (name.length() >= 15) {
           throw new CharLimitExceededException(name);
         }
 

--- a/src/main/java/edu/ucsb/cs156/courses/errors/CharLimitExceededException.java
+++ b/src/main/java/edu/ucsb/cs156/courses/errors/CharLimitExceededException.java
@@ -2,6 +2,6 @@ package edu.ucsb.cs156.courses.errors;
 
 public class CharLimitExceededException extends RuntimeException {
   public CharLimitExceededException(String name) {
-    super("Name: %s too long (Name must be no more than 15 characters)".formatted(name.toString()));
+    super("Name: %s too long (Name must be no more than 15 characters)".formatted(name));
   }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/errors/CharLimitExceededException.java
+++ b/src/main/java/edu/ucsb/cs156/courses/errors/CharLimitExceededException.java
@@ -1,0 +1,7 @@
+package edu.ucsb.cs156.courses.errors;
+
+public class CharLimitExceededException extends RuntimeException {
+  public CharLimitExceededException(String name) {
+    super("Name: %s too long (Name must be no more than 15 characters)".formatted(name.toString()));
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesControllerTests.java
@@ -558,19 +558,20 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
 
     @WithMockUser(roles = { "USER" })
     @Test
-    public void apiCoursesUserCreatesCourseWithInvalidPSID() throws Exception {
+    public void apiPersonalScheduleUserCreatesScheduleWithInvalidName() throws Exception {
         // arrange
         User u = currentUserService.getCurrentUser().getUser();
 
         // act
+        // ThisSixteenChars -> exactly 16 characters to consider boundary change in mutation tests
         MvcResult response = mockMvc.perform(
-                post("/api/personalschedules/post?description=desodknajkf&name=ThisNameIsLongerThanFifteenChars&quarter=W22")
+                post("/api/personalschedules/post?description=desodknajkf&name=ThisSixteenChars&quarter=W22")
                         .with(csrf()))
                 .andExpect(status().isNotFound()).andReturn();
 
         // assert
         Map<String, Object> json = responseToJson(response);
-        assertEquals("Name: ThisNameIsLongerThanFifteenChars too long (Name must be no more than 15 characters)", json.get("message"));
+        assertEquals("Name: ThisSixteenChars too long (Name must be no more than 15 characters)", json.get("message"));
         assertEquals("CharLimitExceededException", json.get("type"));
     }
 

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesControllerTests.java
@@ -556,4 +556,22 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
         assertEquals("PersonalSchedule with id 77 not found", json.get("message"));
     }
 
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void apiCoursesUserCreatesCourseWithInvalidPSID() throws Exception {
+        // arrange
+        User u = currentUserService.getCurrentUser().getUser();
+
+        // act
+        MvcResult response = mockMvc.perform(
+                post("/api/personalschedules/post?description=desodknajkf&name=ThisNameIsLongerThanFifteenChars&quarter=W22")
+                        .with(csrf()))
+                .andExpect(status().isNotFound()).andReturn();
+
+        // assert
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("Name: ThisNameIsLongerThanFifteenChars too long (Name must be no more than 15 characters)", json.get("message"));
+        assertEquals("CharLimitExceededException", json.get("type"));
+    }
+
 }


### PR DESCRIPTION
## Overview

In this PR, we limit the names of new Personal Schedules to not be more than 15 characters. As expected, the corresponding tests for the new implementations were created which passes all correlated tests and kills all mutations.

## Details

When the `/post/` endpoint is called for the Personal Schedules API, the controller checks the length of the name. If the length is more than 15 characters the exception `CharLimitExceededException` is thrown, preventing the schedule from being created. The exception is seen through SwaggerUI below:

<img width="803" alt="Screen Shot 2022-11-21 at 4 07 38 PM" src="https://user-images.githubusercontent.com/75236585/203182964-1883a846-e2ed-47bc-925a-b21b3ba14ccd.png">


In the front end, when an invalid name is submitted to the form, the front end provides a 404 error pop-up on the top right as seen below. (This is the similar behavior as seen in PSCourses which has been the legacy code this implementation is based off of).

![image](https://user-images.githubusercontent.com/75236585/203183784-8dd9d75e-932f-47dd-914c-03ab091af917.png)


Furthermore, we adjust the invalid name field message to mention that the name of the personal schedule must not exceed more than 15 characters (going from `Name is required.` to `Name of less than 15 characters is required.` . The invalid message is seen when the user deletes the name field after as demonstrated below.

<img width="655" alt="Screen Shot 2022-11-21 at 4 13 38 PM" src="https://user-images.githubusercontent.com/75236585/203183628-afa22dcb-e932-4ea9-a509-9ba856efb250.png">

Closes #2 
