### PR TITLE
 Staff f22: Add job to update MongoDB for a single quarter / subject area 

### DIFF
--- a/.github/workflows/10-backend-unit.yml
+++ b/.github/workflows/10-backend-unit.yml
@@ -6,9 +6,10 @@ name: "10-backend-unit: Java Unit tests"
 on:
   workflow_dispatch:
   pull_request:
+    paths: [src/**, pom.xml, lombok.config]
   push:
-  - branches: [ main ]
-  - paths: [src/**, pom.xml, lombok.config]
+    branches: [ main ]
+    paths: [src/**, pom.xml, lombok.config]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/10-backend-unit.yml
+++ b/.github/workflows/10-backend-unit.yml
@@ -7,8 +7,8 @@ on:
   workflow_dispatch:
   pull_request:
   push:
-    branches: [ main ]
-
+  - branches: [ main ]
+  - paths: [src/**, pom.xml, lombok.config]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/12-backend-jacoco.yml
+++ b/.github/workflows/12-backend-jacoco.yml
@@ -24,8 +24,5 @@ jobs:
     - name: Build with Maven
       env:
         TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
-      run: mvn -B test jacoco:report 
-    - name: Upload to Codecov
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      run: bash <(curl -s https://codecov.io/bash)
+      run: mvn -B test jacoco:report verify
+  

--- a/.github/workflows/12-backend-jacoco.yml
+++ b/.github/workflows/12-backend-jacoco.yml
@@ -6,8 +6,10 @@ name: "12-backend-jacoco: Java Test Coverage (Jacoco)"
 on:
   workflow_dispatch:
   pull_request:
+    paths: [src/**, pom.xml, lombok.config]
   push:
     branches: [ main ]
+    paths: [src/**, pom.xml, lombok.config]
 
 jobs:
   build:

--- a/.github/workflows/12-backend-jacoco.yml
+++ b/.github/workflows/12-backend-jacoco.yml
@@ -25,4 +25,9 @@ jobs:
       env:
         TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
       run: mvn -B test jacoco:report verify
-  
+   - name: Upload Jacoco reports to Artifacts
+      if: always() # always upload artifacts, even on failure
+      uses: actions/upload-artifact@v2
+      with:
+        name: jacoco-report
+        path: target/site/jacoco/* 

--- a/.github/workflows/12-backend-jacoco.yml
+++ b/.github/workflows/12-backend-jacoco.yml
@@ -25,7 +25,7 @@ jobs:
       env:
         TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
       run: mvn -B test jacoco:report verify
-   - name: Upload Jacoco reports to Artifacts
+    - name: Upload Jacoco reports to Artifacts
       if: always() # always upload artifacts, even on failure
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/14-backend-pitest.yml
+++ b/.github/workflows/14-backend-pitest.yml
@@ -26,7 +26,7 @@ jobs:
         TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
       run: mvn -B test 
     - name: Pitest
-      run: mvn org.pitest:pitest-maven:mutationCoverage -DmutationThreshold=100 -DcoverageThreshold=100
+      run: mvn org.pitest:pitest-maven:mutationCoverage -DmutationThreshold=100 
     - name: Upload Pitest to Artifacts
       if: always() # always upload artifacts, even on failure
       uses: actions/upload-artifact@v2

--- a/.github/workflows/14-backend-pitest.yml
+++ b/.github/workflows/14-backend-pitest.yml
@@ -26,7 +26,7 @@ jobs:
         TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
       run: mvn -B test 
     - name: Pitest
-      run: mvn test org.pitest:pitest-maven:mutationCoverage
+      run: mvn org.pitest:pitest-maven:mutationCoverage -DmutationThreshold=100
     - name: Upload Pitest to Artifacts
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/14-backend-pitest.yml
+++ b/.github/workflows/14-backend-pitest.yml
@@ -6,9 +6,10 @@ name: "14-backend-pitest: Java Mutation Testing (Pitest)"
 on:
   workflow_dispatch:
   pull_request:
+    paths: [src/**, pom.xml, lombok.config]
   push:
-  - branches: [ main ]
-  - paths: [src/**, pom.xml, lombok.config]
+    branches: [ main ]
+    paths: [src/**, pom.xml, lombok.config]
 
 jobs:
   build:

--- a/.github/workflows/14-backend-pitest.yml
+++ b/.github/workflows/14-backend-pitest.yml
@@ -26,7 +26,7 @@ jobs:
         TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
       run: mvn -B test 
     - name: Pitest
-      run: mvn org.pitest:pitest-maven:mutationCoverage -DmutationThreshold=100
+      run: mvn org.pitest:pitest-maven:mutationCoverage -DmutationThreshold=100 -DcoverageThreshold=100
     - name: Upload Pitest to Artifacts
       if: always() # always upload artifacts, even on failure
       uses: actions/upload-artifact@v2

--- a/.github/workflows/14-backend-pitest.yml
+++ b/.github/workflows/14-backend-pitest.yml
@@ -28,6 +28,7 @@ jobs:
     - name: Pitest
       run: mvn org.pitest:pitest-maven:mutationCoverage -DmutationThreshold=100
     - name: Upload Pitest to Artifacts
+      if: always() # always upload artifacts, even on failure
       uses: actions/upload-artifact@v2
       with:
         name: pitest-mutation-testing

--- a/.github/workflows/14-backend-pitest.yml
+++ b/.github/workflows/14-backend-pitest.yml
@@ -7,7 +7,8 @@ on:
   workflow_dispatch:
   pull_request:
   push:
-    branches: [ main ]
+  - branches: [ main ]
+  - paths: [src/**, pom.xml, lombok.config]
 
 jobs:
   build:

--- a/.github/workflows/30-frontend-tests.yml
+++ b/.github/workflows/30-frontend-tests.yml
@@ -3,9 +3,10 @@ name: "30-frontend-tests: JavaScript, Jest Unit tests"
 on:
   workflow_dispatch:
   pull_request:
+    paths: [frontend/**]
   push:
-    branches:
-      - main
+    branches: [ main ]
+    paths: [frontend/**]
 
 jobs:
   build:

--- a/.github/workflows/32-frontend-coverage.yml
+++ b/.github/workflows/32-frontend-coverage.yml
@@ -3,9 +3,10 @@ name: "32-frontend-coverage: Frontend Coverage (JavaScript/Jest)"
 on:
   workflow_dispatch:
   pull_request:
+    paths: [frontend/**]
   push:
-    branches:
-      - main
+    branches: [ main ]
+    paths: [frontend/**]
 
 jobs:
   build:

--- a/.github/workflows/34-frontend-mutation-testing.yml
+++ b/.github/workflows/34-frontend-mutation-testing.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
 
     strategy:
       matrix:
@@ -28,3 +28,9 @@ jobs:
         working-directory: ./frontend
       - run: npx stryker run
         working-directory: ./frontend
+      - name: Upload stryker report to Artifacts
+          if: always() # always upload artifacts, even if tests fail
+          uses: actions/upload-artifact@v2
+          with:
+            name: stryker-report
+            path: frontend/reports/mutation/html/*

--- a/.github/workflows/34-frontend-mutation-testing.yml
+++ b/.github/workflows/34-frontend-mutation-testing.yml
@@ -3,9 +3,10 @@ name: "34-frontend-mutation-testing: Stryker JS Mutation Testing (JavaScript/Jes
 on:
   workflow_dispatch:
   pull_request:
+    paths: [frontend/**]
   push:
-    branches:
-      - main
+    branches: [ main ]
+    paths: [frontend/**]
 
 jobs:
   build:

--- a/.github/workflows/36-frontend-eslint.yml
+++ b/.github/workflows/36-frontend-eslint.yml
@@ -3,9 +3,10 @@ name: "36-frontend-eslint: JavaScript style checking"
 on:
   workflow_dispatch:
   pull_request:
+    paths: [frontend/**]
   push:
-    branches:
-      - main
+    branches: [ main ]
+    paths: [frontend/**]
 
 jobs:
   lint:

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 frontend/.stryker-tmp
 frontend/reports
+frontend/strykerTmp
 
 # Don't check in a built storybook #
 

--- a/frontend/.storybook/main.js
+++ b/frontend/.storybook/main.js
@@ -11,7 +11,8 @@ module.exports = {
   "addons": [
     "@storybook/addon-links",
     "@storybook/addon-essentials",
-    "@storybook/preset-create-react-app"
+    "@storybook/preset-create-react-app",
+    'storybook-addon-mock',
   ],
   webpackFinal: async (config) => {
     config.plugins.push(new WebpackPluginFailBuildOnWarning());

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -48,7 +48,8 @@
         "eslint-plugin-react": "^7.30.0",
         "eslint-plugin-react-hooks": "^4.2.1-rc.0-next-64223fed8-20220210",
         "jest-mock-console": "^1.1.0",
-        "react-test-renderer": "^17.0.2"
+        "react-test-renderer": "^17.0.2",
+        "storybook-addon-mock": "^3.2.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1847,11 +1848,11 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.17.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
-      "integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
+      "version": "7.20.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.1.tgz",
+      "integrity": "sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.10"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -25098,6 +25099,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/mock-xmlhttprequest": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/mock-xmlhttprequest/-/mock-xmlhttprequest-7.0.4.tgz",
+      "integrity": "sha512-hA0fIHy/74p5DE0rdmrpU0sV1U+gnWTcgShWequGRLy0L1eT+zY0ozFukawpLaxMwIA+orRcqFRElYwT+5p81A==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -26483,12 +26493,12 @@
       }
     },
     "node_modules/polished": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/polished/-/polished-4.1.4.tgz",
-      "integrity": "sha512-Nq5Mbza+Auo7N3sQb1QMFaQiDO+4UexWuSGR7Cjb4Sw11SZIJcrrFtiZ+L0jT9MBsUsxDboHVASbCLbE1rnECg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/polished/-/polished-4.2.2.tgz",
+      "integrity": "sha512-Sz2Lkdxz6F2Pgnpi9U5Ng/WdWAUZxmHrNPoVlm3aAemxoy2Qy7LGjQg4uf8qKelDAUW94F4np3iH2YPf2qefcQ==",
       "dev": true,
       "dependencies": {
-        "@babel/runtime": "^7.16.7"
+        "@babel/runtime": "^7.17.8"
       },
       "engines": {
         "node": ">=10"
@@ -29443,9 +29453,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.14.5",
@@ -31439,6 +31449,39 @@
       "version": "2.13.1",
       "resolved": "https://registry.npmjs.org/store2/-/store2-2.13.1.tgz",
       "integrity": "sha512-iJtHSGmNgAUx0b/MCS6ASGxb//hGrHHRgzvN+K5bvkBTN7A9RTpPSf1WSp+nPGvWCJ1jRnvY7MKnuqfoi3OEqg==",
+      "dev": true
+    },
+    "node_modules/storybook-addon-mock": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/storybook-addon-mock/-/storybook-addon-mock-3.2.0.tgz",
+      "integrity": "sha512-LaggsF/6Lt0AyHiotIEVQpwKfIiZ3KsNqtdXKVnIdOetjaD7GaOQeX0jIZiZUFX/i6QLmMuNoXFngqqkdVtfSg==",
+      "dev": true,
+      "dependencies": {
+        "mock-xmlhttprequest": "^7.0.3",
+        "path-to-regexp": "^6.2.0",
+        "polished": "^4.2.2"
+      },
+      "peerDependencies": {
+        "@storybook/addons": "^6.4.0",
+        "@storybook/api": "^6.4.0",
+        "@storybook/components": "^6.4.0",
+        "@storybook/theming": "^6.4.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/storybook-addon-mock/node_modules/path-to-regexp": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
       "dev": true
     },
     "node_modules/stream-browserify": {
@@ -36087,11 +36130,11 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.17.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
-      "integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
+      "version": "7.20.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.1.tgz",
+      "integrity": "sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==",
       "requires": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.10"
       }
     },
     "@babel/runtime-corejs3": {
@@ -53893,6 +53936,12 @@
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "dev": true
     },
+    "mock-xmlhttprequest": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/mock-xmlhttprequest/-/mock-xmlhttprequest-7.0.4.tgz",
+      "integrity": "sha512-hA0fIHy/74p5DE0rdmrpU0sV1U+gnWTcgShWequGRLy0L1eT+zY0ozFukawpLaxMwIA+orRcqFRElYwT+5p81A==",
+      "dev": true
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -54990,12 +55039,12 @@
       }
     },
     "polished": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/polished/-/polished-4.1.4.tgz",
-      "integrity": "sha512-Nq5Mbza+Auo7N3sQb1QMFaQiDO+4UexWuSGR7Cjb4Sw11SZIJcrrFtiZ+L0jT9MBsUsxDboHVASbCLbE1rnECg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/polished/-/polished-4.2.2.tgz",
+      "integrity": "sha512-Sz2Lkdxz6F2Pgnpi9U5Ng/WdWAUZxmHrNPoVlm3aAemxoy2Qy7LGjQg4uf8qKelDAUW94F4np3iH2YPf2qefcQ==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.16.7"
+        "@babel/runtime": "^7.17.8"
       }
     },
     "portfinder": {
@@ -57023,9 +57072,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "regenerator-transform": {
       "version": "0.14.5",
@@ -58607,6 +58656,25 @@
       "resolved": "https://registry.npmjs.org/store2/-/store2-2.13.1.tgz",
       "integrity": "sha512-iJtHSGmNgAUx0b/MCS6ASGxb//hGrHHRgzvN+K5bvkBTN7A9RTpPSf1WSp+nPGvWCJ1jRnvY7MKnuqfoi3OEqg==",
       "dev": true
+    },
+    "storybook-addon-mock": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/storybook-addon-mock/-/storybook-addon-mock-3.2.0.tgz",
+      "integrity": "sha512-LaggsF/6Lt0AyHiotIEVQpwKfIiZ3KsNqtdXKVnIdOetjaD7GaOQeX0jIZiZUFX/i6QLmMuNoXFngqqkdVtfSg==",
+      "dev": true,
+      "requires": {
+        "mock-xmlhttprequest": "^7.0.3",
+        "path-to-regexp": "^6.2.0",
+        "polished": "^4.2.2"
+      },
+      "dependencies": {
+        "path-to-regexp": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+          "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
+          "dev": true
+        }
+      }
     },
     "stream-browserify": {
       "version": "2.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,7 +43,8 @@
     "eslint-plugin-react": "^7.30.0",
     "eslint-plugin-react-hooks": "^4.2.1-rc.0-next-64223fed8-20220210",
     "jest-mock-console": "^1.1.0",
-    "react-test-renderer": "^17.0.2"
+    "react-test-renderer": "^17.0.2",
+    "storybook-addon-mock": "^3.2.0"
   },
   "scripts": {
     "start": "env-cmd -f ../.env -e development react-scripts start",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -4,6 +4,7 @@ import ProfilePage from "main/pages/ProfilePage";
 import AdminUsersPage from "main/pages/AdminUsersPage";
 import AdminLoadSubjectsPage from "main/pages/AdminLoadSubjectsPage";
 import AdminPersonalSchedulesPage from "main/pages/AdminPersonalSchedulePage";
+import AdminJobsPage from "main/pages/AdminJobsPage";
 
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
@@ -34,6 +35,7 @@ function App() {
               <Route exact path="/admin/users" element={<AdminUsersPage />} />
               <Route exact path="/admin/loadsubjects" element={<AdminLoadSubjectsPage />} />
               <Route exact path="/admin/personalschedule" element={<AdminPersonalSchedulesPage />} />
+              <Route path="/admin/jobs" element={<AdminJobsPage />} />
             </>
           )
         }

--- a/frontend/src/fixtures/jobsFixtures.js
+++ b/frontend/src/fixtures/jobsFixtures.js
@@ -1,65 +1,65 @@
 const jobsFixtures = {
     oneCompleteJob:  {
         "id": 1,
-        "createdAt": "2022-11-13T19:49:58.097465",
-        "updatedAt": "2022-11-13T19:49:59.203879",
+        "createdAt": "2022-11-13T19:49:58.097465-08:00",
+        "updatedAt": "2022-11-13T19:49:59.203879-08:00",
         "status": "complete",
         "log": "Hello World! from test job!\nGoodbye from test job!"
       },
     oneRunningJob:  {
         "id": 6,
-        "createdAt": "2022-11-13T19:50:37.252253",
-        "updatedAt": "2022-11-13T19:50:37.258798",
+        "createdAt": "2022-11-13T19:50:37.252253-08:00",
+        "updatedAt": "2022-11-13T19:50:37.258798-08:00",
         "status": "running",
         "log": "Hello World! from test job!"
       },
     oneErroredJob:  {
         "id": 5,
-        "createdAt": "2022-11-13T19:50:34.097377",
-        "updatedAt": "2022-11-13T19:50:39.122652",
+        "createdAt": "2022-11-13T19:50:34.097377-08:00",
+        "updatedAt": "2022-11-13T19:50:39.122652-08:00",
         "status": "error",
         "log": "Hello World! from test job!\nFail!"
       },
     sixJobs: [
       {
         "id": 1,
-        "createdAt": "2022-11-13T19:49:58.097465",
-        "updatedAt": "2022-11-13T19:49:59.203879",
+        "createdAt": "2022-11-13T19:49:58.097465-08:00",
+        "updatedAt": "2022-11-13T19:49:59.203879-08:00",
         "status": "complete",
         "log": "Hello World! from test job!\nGoodbye from test job!"
       },
       {
         "id": 2,
-        "createdAt": "2022-11-13T19:50:00.349036",
-        "updatedAt": "2022-11-13T19:50:01.387745",
+        "createdAt": "2022-11-13T19:50:00.349036-08:00",
+        "updatedAt": "2022-11-13T19:50:01.387745-08:00",
         "status": "complete",
         "log": "Hello World! from test job!\nGoodbye from test job!"
       },
       {
         "id": 3,
-        "createdAt": "2022-11-13T19:50:16.810569",
-        "updatedAt": "2022-11-13T19:50:17.844532",
+        "createdAt": "2022-11-13T19:50:16.810569-08:00",
+        "updatedAt": "2022-11-13T19:50:17.844532-08:00",
         "status": "complete",
         "log": "Hello World! from test job!\nGoodbye from test job!"
       },
       {
         "id": 4,
-        "createdAt": "2022-11-13T19:50:17.770892",
-        "updatedAt": "2022-11-13T19:50:18.798021",
+        "createdAt": "2022-11-13T19:50:17.770892-08:00",
+        "updatedAt": "2022-11-13T19:50:18.798021-08:00",
         "status": "complete",
         "log": "Hello World! from test job!\nGoodbye from test job!"
       },
       {
         "id": 6,
-        "createdAt": "2022-11-13T19:50:37.252253",
-        "updatedAt": "2022-11-13T19:50:37.258798",
+        "createdAt": "2022-11-13T19:50:37.252253-08:00",
+        "updatedAt": "2022-11-13T19:50:37.258798-08:00",
         "status": "running",
         "log": "Hello World! from test job!"
       },
       {
         "id": 5,
-        "createdAt": "2022-11-13T19:50:34.097377",
-        "updatedAt": "2022-11-13T19:50:39.122652",
+        "createdAt": "2022-11-13T19:50:34.097377-08:00",
+        "updatedAt": "2022-11-13T19:50:39.122652-08:00",
         "status": "error",
         "log": "Hello World! from test job!\nFail!"
       }

--- a/frontend/src/fixtures/jobsFixtures.js
+++ b/frontend/src/fixtures/jobsFixtures.js
@@ -1,0 +1,77 @@
+const jobsFixtures = {
+    oneCompleteJob:  {
+        "id": 1,
+        "createdAt": "2022-11-13T19:49:58.097465",
+        "updatedAt": "2022-11-13T19:49:59.203879",
+        "status": "complete",
+        "log": "Hello World! from test job!\nGoodbye from test job!"
+      },
+    oneRunningJob:  {
+        "id": 6,
+        "createdAt": "2022-11-13T19:50:37.252253",
+        "updatedAt": "2022-11-13T19:50:37.258798",
+        "status": "running",
+        "log": "Hello World! from test job!"
+      },
+    oneErroredJob:  {
+        "id": 5,
+        "createdAt": "2022-11-13T19:50:34.097377",
+        "updatedAt": "2022-11-13T19:50:39.122652",
+        "status": "error",
+        "log": "Hello World! from test job!\nFail!"
+      },
+    sixJobs: [
+      {
+        "id": 1,
+        "createdAt": "2022-11-13T19:49:58.097465",
+        "updatedAt": "2022-11-13T19:49:59.203879",
+        "status": "complete",
+        "log": "Hello World! from test job!\nGoodbye from test job!"
+      },
+      {
+        "id": 2,
+        "createdAt": "2022-11-13T19:50:00.349036",
+        "updatedAt": "2022-11-13T19:50:01.387745",
+        "status": "complete",
+        "log": "Hello World! from test job!\nGoodbye from test job!"
+      },
+      {
+        "id": 3,
+        "createdAt": "2022-11-13T19:50:16.810569",
+        "updatedAt": "2022-11-13T19:50:17.844532",
+        "status": "complete",
+        "log": "Hello World! from test job!\nGoodbye from test job!"
+      },
+      {
+        "id": 4,
+        "createdAt": "2022-11-13T19:50:17.770892",
+        "updatedAt": "2022-11-13T19:50:18.798021",
+        "status": "complete",
+        "log": "Hello World! from test job!\nGoodbye from test job!"
+      },
+      {
+        "id": 6,
+        "createdAt": "2022-11-13T19:50:37.252253",
+        "updatedAt": "2022-11-13T19:50:37.258798",
+        "status": "running",
+        "log": "Hello World! from test job!"
+      },
+      {
+        "id": 5,
+        "createdAt": "2022-11-13T19:50:34.097377",
+        "updatedAt": "2022-11-13T19:50:39.122652",
+        "status": "error",
+        "log": "Hello World! from test job!\nFail!"
+      }
+    ],
+    testJobFailFalseSleepMs1000: {
+      "fail": false,
+      "sleepMs": 1000
+    },
+    testJobFailTrueSleepMs1000: {
+      "fail": false,
+      "sleepMs": 1000
+    },
+};
+
+export default jobsFixtures;

--- a/frontend/src/main/components/Jobs/JobComingSoon.js
+++ b/frontend/src/main/components/Jobs/JobComingSoon.js
@@ -1,0 +1,7 @@
+function JobComingSoon() {
+  return (
+    <p>Coming Soon! (The form for this job has not yet been created)</p>
+  );
+}
+
+export default JobComingSoon;

--- a/frontend/src/main/components/Jobs/JobsTable.js
+++ b/frontend/src/main/components/Jobs/JobsTable.js
@@ -1,0 +1,39 @@
+import React from "react";
+import OurTable, {PlaintextColumn, DateColumn} from "main/components/OurTable";
+
+export default function JobsTable({ jobs }) {
+
+    const testid = "JobsTable";
+
+    const columns = [
+        {
+            Header: 'id',
+            accessor: 'id', // accessor is the "key" in the data
+        },
+        DateColumn('Created', (cell)=>cell.row.original.createdAt),
+        DateColumn('Updated', (cell)=>cell.row.original.updatedAt),
+        {
+            Header:'Status',
+            accessor: 'status'
+        },
+        PlaintextColumn('Log', (cell)=>cell.row.original.log),
+    ];
+    
+    const sortees = React.useMemo(
+        () => [
+          {
+            id: "id",
+            desc: true
+          }
+        ],
+       // Stryker disable next-line all
+        []
+      );
+
+    return <OurTable
+        data={jobs}
+        columns={columns}
+        testid={testid}
+        initialState={{ sortBy: sortees }}
+    />;
+}; 

--- a/frontend/src/main/components/Jobs/TestJobForm.js
+++ b/frontend/src/main/components/Jobs/TestJobForm.js
@@ -1,0 +1,61 @@
+import { Button, Form } from "react-bootstrap";
+import { useForm } from "react-hook-form";
+
+function TestJobForm({ submitAction }) {
+
+ const defaultValues = {
+    fail: false,
+    sleepMs: 1000
+};
+
+  // Stryker disable all
+  const {
+    register,
+    formState: { errors },
+    handleSubmit,
+  } = useForm(
+    { defaultValues: defaultValues }
+  );
+  // Stryker enable all
+
+  const testid = "TestJobForm";
+
+  return (
+    <Form onSubmit={handleSubmit(submitAction)}>
+      
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="fail">Fail? (if checked, job will fail, to test error handling)</Form.Label>
+        <Form.Check 
+          data-testid={`${testid}-fail`}
+          type="checkbox"
+          id="fail"
+          {...register("fail")}
+        />
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="sleepMs">Sleep (milliseconds)</Form.Label>
+        <Form.Control
+          id="sleepMs"
+          data-testid={`${testid}-sleepMs`}
+          type="number"
+          step="100"
+          isInvalid={!!errors.sleepMs}
+          {...register("sleepMs", {
+            valueAsNumber: true,
+            required: "sleepMs is required (0 is ok)",
+            min: { value: 0, message: "sleepMs must be positive" },
+            max: { value: 60000, message: "sleepMs may not be > 60000 (1 minute)" },
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.sleepMs?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Button type="submit" data-testid="TestJobForm-Submit-Button">Submit</Button>
+    </Form>
+  );
+}
+
+export default TestJobForm;

--- a/frontend/src/main/components/Jobs/UpdateCoursesJobForm.js
+++ b/frontend/src/main/components/Jobs/UpdateCoursesJobForm.js
@@ -36,7 +36,9 @@ const UpdateCoursesJobForm = ({ callback }) => {
 
   const handleSubmit = (event) => {
     event.preventDefault();
-    callback({quarter, subject});
+    console.log("UpdateCoursesJobForm: quarter", quarter);
+    console.log("UpdateCoursesJobForm: subject", subject);
+    callback({ quarter, subject});
   };
 
   // Stryker disable all : Stryker is testing by changing the padding to 0. But this is simply a visual optimization as it makes it look better

--- a/frontend/src/main/components/Jobs/UpdateCoursesJobForm.js
+++ b/frontend/src/main/components/Jobs/UpdateCoursesJobForm.js
@@ -1,16 +1,14 @@
 import { useState } from "react";
 import { Form, Button, Container, Row, Col } from "react-bootstrap";
 
-import { allTheLevels } from "fixtures/levelsFixtures";
 import { quarterRange } from "main/utils/quarterUtilities";
 
 import { useSystemInfo } from "main/utils/systemInfo";
 import SingleQuarterDropdown from "../Quarters/SingleQuarterDropdown";
 import SingleSubjectDropdown from "../Subjects/SingleSubjectDropdown";
-import SingleLevelDropdown from "../Levels/SingleLevelDropdown";
 import { useBackend  } from "main/utils/useBackend";
 
-const BasicCourseSearchForm = ({ fetchJSON }) => {
+const UpdateCoursesJobForm = ({ callback }) => {
 
   const { data: systemInfo } = useSystemInfo();
 
@@ -24,7 +22,6 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
   // Stryker disable all : not sure how to test/mock local storage
   const localSubject = localStorage.getItem("BasicSearch.Subject");
   const localQuarter = localStorage.getItem("BasicSearch.Quarter");
-  const localLevel = localStorage.getItem("BasicSearch.CourseLevel");
 
   const { data: subjects, error: _error, status: _status } =
   useBackend(
@@ -36,11 +33,10 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
 
   const [quarter, setQuarter] = useState(localQuarter || quarters[0].yyyyq);
   const [subject, setSubject] = useState(localSubject || {});
-  const [level, setLevel] = useState(localLevel || "U");
 
   const handleSubmit = (event) => {
     event.preventDefault();
-    fetchJSON(event, { quarter, subject, level });
+    callback({quarter, subject});
   };
 
   // Stryker disable all : Stryker is testing by changing the padding to 0. But this is simply a visual optimization as it makes it look better
@@ -64,19 +60,11 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
               controlId={"BasicSearch.Subject"}
             />
           </Col>
-          <Col md="auto">
-            <SingleLevelDropdown
-              levels={allTheLevels}
-              level={level}
-              setLevel={setLevel}
-              controlId={"BasicSearch.Level"}
-            />
-          </Col>
         </Row>
         <Row style={{ paddingTop: 10, paddingBottom: 10 }}>
           <Col md="auto">
             <Button variant="primary" type="submit">
-              Submit
+              Update Courses
             </Button>
           </Col>
         </Row>
@@ -85,4 +73,4 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
   );
 };
 
-export default BasicCourseSearchForm;
+export default UpdateCoursesJobForm;

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -89,7 +89,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                     <NavDropdown.Item href="/admin/users" data-testid="appnavbar-admin-users">Users</NavDropdown.Item>
                     <NavDropdown.Item href="/admin/personalschedule" data-testid="appnavbar-admin-personalschedule">Personal Schedules</NavDropdown.Item>
                     <NavDropdown.Item href="/admin/loadsubjects" data-testid="appnavbar-admin-loadsubjects">Load Subjects</NavDropdown.Item>
-
+                    <NavDropdown.Item href="/admin/jobs" data-testid="appnavbar-admin-jobs">Manage Jobs</NavDropdown.Item>
                   </NavDropdown>
                 )
               }

--- a/frontend/src/main/components/OurTable.js
+++ b/frontend/src/main/components/OurTable.js
@@ -1,8 +1,9 @@
 import React from "react";
 import { useTable, useSortBy } from 'react-table'
 import { Table, Button } from "react-bootstrap";
+import Plaintext from "main/components/Utils/Plaintext";
 
-export default function OurTable({ columns, data, testid = "testid" }) {
+export default function OurTable({ columns, data, testid = "testid", ...rest }) {
 
   const {
     getTableProps,
@@ -10,7 +11,13 @@ export default function OurTable({ columns, data, testid = "testid" }) {
     headerGroups,
     rows,
     prepareRow,
-  } = useTable({ columns, data }, useSortBy)
+  } = useTable({
+    columns,
+    data,
+    ...(rest.initialState && {
+      initialState: rest.initialState
+    })
+  }, useSortBy)
 
   return (
     <Table {...getTableProps()} striped bordered hover >
@@ -96,6 +103,36 @@ export function ButtonColumn(label, variant, callback, testid) {
         {label}
       </Button>
     )
+  }
+  return column;
+}
+
+export function PlaintextColumn(label, getText) {
+  const column = {
+    Header: label,
+    id: label,
+    Cell: ({ cell }) => (
+      <Plaintext text={getText(cell)} />
+    )
+  }
+  return column;
+}
+
+export function DateColumn(label, getDate) {
+  const options = {
+    year: 'numeric', month: 'numeric', day: 'numeric',
+    hour: 'numeric', minute: 'numeric', second: 'numeric',
+    hour12: false,
+    timeZone: 'America/Los_Angeles'
+  };
+  const column = {
+    Header: label,
+    id: label,
+    Cell: ({ cell }) => {
+      const date = new Date(getDate(cell));
+      const formattedDate = new Intl.DateTimeFormat('en-US', options).format(date);
+      return (<>{formattedDate}</>)
+    }
   }
   return column;
 }

--- a/frontend/src/main/components/Subjects/SingleSubjectDropdown.js
+++ b/frontend/src/main/components/Subjects/SingleSubjectDropdown.js
@@ -36,8 +36,9 @@ const SingleSubjectDropdown = ({
         value={subjectState}
         onChange={handleSubjectOnChange}
       >
-        {subjects.map(function (object, i) {
-          const key = `${controlId}-option-${i}`;
+        {subjects.map(function (object) {
+          const subjectCode = object.subjectCode.replace(/ /g, "-");
+          const key = `${controlId}-option-${subjectCode}`;
           return (
             <option key={key} data-testid={key} value={object.subjectCode}>
               {object.subjectCode} - {object.subjectTranslation}

--- a/frontend/src/main/components/Utils/Plaintext.js
+++ b/frontend/src/main/components/Utils/Plaintext.js
@@ -1,5 +1,7 @@
 // based in part on this SO answer: https://codereview.stackexchange.com/a/211511
 
+import PlaintextLine from "./PlaintextLine";
+
 export default function Plaintext({text}) {
   if (text==null) {
     return (<pre data-testid="plaintext-empty"></pre>)
@@ -8,14 +10,9 @@ export default function Plaintext({text}) {
   const [firstLine, ...rest] = textToRender.split('\n')
   return (
     <pre data-testid="plaintext">
-      <span>{ firstLine }</span>
+      <span key={"span-0"}>{ firstLine }</span>
       {
-        rest.map((line) => (
-          <>
-            <br />
-            <span>{ line }</span>
-          </>
-        ))
+        rest.map((line,index) => <PlaintextLine key={index+1} text={line} />)
       }
     </pre>
   );

--- a/frontend/src/main/components/Utils/Plaintext.js
+++ b/frontend/src/main/components/Utils/Plaintext.js
@@ -2,17 +2,18 @@
 
 import PlaintextLine from "./PlaintextLine";
 
-export default function Plaintext({text}) {
-  if (text==null) {
+export default function Plaintext({ text }) {
+  if (text == null) {
     return (<pre data-testid="plaintext-empty"></pre>)
   }
   const textToRender = typeof text === "string" ? text : JSON.stringify(text, null, 2);
   const [firstLine, ...rest] = textToRender.split('\n')
   return (
     <pre data-testid="plaintext">
-      <span key={"span-0"}>{ firstLine }</span>
+      <span key={"0"}>{firstLine}</span>
       {
-        rest.map((line,index) => <PlaintextLine key={index+1} text={line} />)
+        // Stryker disable next-line ArithmeticOperator : key value is internal to React and not exposed to tests
+        rest.map((line, index) => <PlaintextLine key={index + 1} text={line} />)
       }
     </pre>
   );

--- a/frontend/src/main/components/Utils/Plaintext.js
+++ b/frontend/src/main/components/Utils/Plaintext.js
@@ -1,0 +1,22 @@
+// based in part on this SO answer: https://codereview.stackexchange.com/a/211511
+
+export default function Plaintext({text}) {
+  if (text==null) {
+    return (<pre data-testid="plaintext-empty"></pre>)
+  }
+  const textToRender = typeof text === "string" ? text : JSON.stringify(text, null, 2);
+  const [firstLine, ...rest] = textToRender.split('\n')
+  return (
+    <pre data-testid="plaintext">
+      <span>{ firstLine }</span>
+      {
+        rest.map((line) => (
+          <>
+            <br />
+            <span>{ line }</span>
+          </>
+        ))
+      }
+    </pre>
+  );
+}

--- a/frontend/src/main/components/Utils/PlaintextLine.js
+++ b/frontend/src/main/components/Utils/PlaintextLine.js
@@ -1,0 +1,9 @@
+// based in part on this SO answer: https://codereview.stackexchange.com/a/211511
+
+export default function PlaintextLine({ text }) {
+    return (
+        <>
+            <br /><span >{text}</span>
+        </>
+    )
+}

--- a/frontend/src/main/pages/AdminJobsPage.js
+++ b/frontend/src/main/pages/AdminJobsPage.js
@@ -1,0 +1,87 @@
+import React from "react";
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import JobsTable from "main/components/Jobs/JobsTable";
+import { useBackend } from "main/utils/useBackend";
+import Accordion from 'react-bootstrap/Accordion';
+import TestJobForm from "main/components/Jobs/TestJobForm";
+import JobComingSoon from "main/components/Jobs/JobComingSoon";
+
+import { useBackendMutation } from "main/utils/useBackend";
+
+const AdminJobsPage = () => {
+
+    const refreshJobsIntervalMilliseconds = 5000;
+
+    // test job 
+
+    const objectToAxiosParamsTestJob = (data) => ({
+        url: `/api/jobs/launch/testjob?fail=${data.fail}&sleepMs=${data.sleepMs}`,
+        method: "POST"
+    });
+
+    // Stryker disable all
+    const testJobMutation = useBackendMutation(
+        objectToAxiosParamsTestJob,
+        {  },
+        ["/api/jobs/all"]
+    );
+    // Stryker enable all
+
+    const submitTestJob = async (data) => {
+        console.log("submitTestJob, data=", data);
+        testJobMutation.mutate(data);
+    }
+
+    // Stryker disable all 
+    const { data: jobs, error: _error, status: _status } =
+        useBackend(
+            ["/api/jobs/all"],
+            {
+                method: "GET",
+                url: "/api/jobs/all",
+            },
+            [],
+            { refetchInterval: refreshJobsIntervalMilliseconds }
+        );
+    // Stryker enable  all 
+
+    const jobLaunchers = [
+        {
+            name: "Test Job",
+            form:  <TestJobForm submitAction={submitTestJob} />
+        },
+        {
+            name: "Update Courses Database",
+            form: <JobComingSoon />
+        },
+        {
+            name: "Update Grade Info",
+            form: <JobComingSoon />
+        },
+    ]
+
+
+    return (
+        <BasicLayout>
+            <h2 className="p-3">Launch Jobs</h2>
+            <Accordion>
+                {
+                    jobLaunchers.map((jobLauncher, index) => (
+                        <Accordion.Item eventKey={index}>
+                            <Accordion.Header>{jobLauncher.name}</Accordion.Header>
+                            <Accordion.Body>
+                                {jobLauncher.form}
+                            </Accordion.Body>
+                        </Accordion.Item>
+                    ))
+                }
+            </Accordion>
+
+            <h2 className="p-3">Job Status</h2>
+
+            <JobsTable jobs={jobs} />
+        </BasicLayout>
+    );
+};
+
+export default AdminJobsPage;

--- a/frontend/src/main/pages/AdminJobsPage.js
+++ b/frontend/src/main/pages/AdminJobsPage.js
@@ -7,6 +7,7 @@ import TestJobForm from "main/components/Jobs/TestJobForm";
 import JobComingSoon from "main/components/Jobs/JobComingSoon";
 
 import { useBackendMutation } from "main/utils/useBackend";
+import UpdateCoursesJobForm from "main/components/Jobs/UpdateCoursesJobForm";
 
 const AdminJobsPage = () => {
 
@@ -22,7 +23,7 @@ const AdminJobsPage = () => {
     // Stryker disable all
     const testJobMutation = useBackendMutation(
         objectToAxiosParamsTestJob,
-        {  },
+        {},
         ["/api/jobs/all"]
     );
     // Stryker enable all
@@ -30,6 +31,26 @@ const AdminJobsPage = () => {
     const submitTestJob = async (data) => {
         console.log("submitTestJob, data=", data);
         testJobMutation.mutate(data);
+    }
+
+    // ***** update courses job *******
+
+    const objectToAxiosParamsUpdateCoursesJob = (data) => ({
+        url: `/api/jobs/launch/updateCourses?quarterYYYYQ=${data.quarter}&subjectArea=${data.subject}`,
+        method: "POST"
+    });
+
+    // Stryker disable all
+    const updateCoursesJobMutation = useBackendMutation(
+        objectToAxiosParamsUpdateCoursesJob,
+        {},
+        ["/api/jobs/all"]
+    );
+    // Stryker enable all
+
+    const submitUpdateCoursesJob = async (data) => {
+        console.log("submitUpdateCoursesJob, data=", data);
+        updateCoursesJobMutation.mutate(data);
     }
 
     // Stryker disable all 
@@ -48,11 +69,11 @@ const AdminJobsPage = () => {
     const jobLaunchers = [
         {
             name: "Test Job",
-            form:  <TestJobForm submitAction={submitTestJob} />
+            form: <TestJobForm submitAction={submitTestJob} />
         },
         {
             name: "Update Courses Database",
-            form: <JobComingSoon />
+            form: <UpdateCoursesJobForm callback={submitUpdateCoursesJob}  />
         },
         {
             name: "Update Grade Info",
@@ -67,7 +88,7 @@ const AdminJobsPage = () => {
             <Accordion>
                 {
                     jobLaunchers.map((jobLauncher, index) => (
-                        <Accordion.Item eventKey={index}>
+                        <Accordion.Item eventKey={index} key={index}>
                             <Accordion.Header>{jobLauncher.name}</Accordion.Header>
                             <Accordion.Body>
                                 {jobLauncher.form}

--- a/frontend/src/main/pages/AdminUsersPage.js
+++ b/frontend/src/main/pages/AdminUsersPage.js
@@ -9,7 +9,10 @@ const AdminUsersPage = () => {
         useBackend(
             // Stryker disable next-line all : don't test internal caching of React Query
             ["/api/admin/users"],
-            { method: "GET", url: "/api/admin/users" },
+            {
+                // Stryker disable next-line StringLiteral : GET is default, so replacing with "" is an equivalent mutation
+                 method: "GET", 
+                 url: "/api/admin/users" },
             []
         );
 

--- a/frontend/src/main/pages/Courses/PSCourseIndexPage.js
+++ b/frontend/src/main/pages/Courses/PSCourseIndexPage.js
@@ -13,7 +13,10 @@ export default function CoursesIndexPage() {
         useBackend(
             // Stryker disable next-line all : don't test internal caching of React Query
             ["/api/courses/user/all"],
-            { method: "GET", url: "/api/courses/user/all" },
+            { 
+               // Stryker disable next-line StringLiteral : GET is default, so replacing with "" is an equivalent mutation
+                method: "GET", 
+                url: "/api/courses/user/all" },
             []
         );
 

--- a/frontend/src/main/utils/useBackend.js
+++ b/frontend/src/main/utils/useBackend.js
@@ -25,53 +25,47 @@ import { toast } from "react-toastify";
 //     []
 // );
 
-export function useBackend(queryKey, axiosParameters, initialData) {
+export function useBackend(queryKey, axiosParameters, initialData, rest) {
 
-    return useQuery(queryKey, async () => {
-        try {
-            const response = await axios(axiosParameters);
-            return response.data;
-        } catch (e) {
-            const errorMessage = `Error communicating with backend via ${axiosParameters.method} on ${axiosParameters.url}`;
-            toast(errorMessage);
-            console.error(errorMessage, e);
+    return useQuery({
+        queryKey: queryKey,
+        queryFn: async () => {
+            try {
+                const response = await axios(axiosParameters);
+                return response.data;
+            } catch (e) {
+                const errorMessage = `useBackend: Error communicating with backend via ${axiosParameters.method} on ${axiosParameters.url}: ${e}`;
+                toast(errorMessage, { type: "error" });
+                console.error(errorMessage);
+            }
             throw e;
-        }
-    }, {
-        initialData
+        },
+        onError: (e) => {
+            const errorMessage = `Error communicating with backend via ${axiosParameters.method} on ${axiosParameters.url}`;
+            toast(errorMessage, { type: "error" });
+            console.error(errorMessage);
+        },
+        initialData: initialData,
+        ...rest
     });
 }
 
-// const wrappedParams = async (params) =>
-//   await ( await axios(params)).data;
-
-
-const reportAxiosError = (error) => {
-    console.error("Axios Error:", error);
-    toast(`Axios Error: ${error}`);
-    return null;
-};
-
 const wrappedParams = async (params) => {
-    try {
-        return await (await axios(params)).data;
-    } catch (rejectedValue) {
-        reportAxiosError(rejectedValue);
-        throw rejectedValue;
-    }
+    return await (await axios(params)).data;
 };
 
-export function useBackendMutation(objectToAxiosParams, useMutationParams, queryKey=null) {
+export function useBackendMutation(objectToAxiosParams, useMutationParams, queryKey = null) {
     const queryClient = useQueryClient();
 
     return useMutation((object) => wrappedParams(objectToAxiosParams(object)), {
-        onError: (data) => {
-            toast(`${data}`)
+        onError: (error) => {
+            const errorMessage = `useBackendMutation: Error communicating with backend via ${error.response.config.method} on ${error.response.config.url}`;
+            toast(errorMessage, { type: "error" });
         },
-        // Stryker disable all: Not sure how to set up the complex behavior needed to test this
+        // Stryker disable all : Not sure how to set up the complex behavior needed to test this
         onSettled: () => {
-            if (queryKey!==null)
-             queryClient.invalidateQueries(queryKey);
+            if (queryKey !== null)
+                queryClient.invalidateQueries(queryKey);
         },
         // Stryker enable all
         retry: false,

--- a/frontend/src/main/utils/useBackend.js
+++ b/frontend/src/main/utils/useBackend.js
@@ -37,11 +37,11 @@ export function useBackend(queryKey, axiosParameters, initialData, rest) {
                 const errorMessage = `useBackend: Error communicating with backend via ${axiosParameters.method} on ${axiosParameters.url}: ${e}`;
                 toast(errorMessage, { type: "error" });
                 console.error(errorMessage);
+                throw e;
             }
-            throw e;
         },
         onError: (e) => {
-            const errorMessage = `Error communicating with backend via ${axiosParameters.method} on ${axiosParameters.url}`;
+            const errorMessage = `Error communicating with backend via ${axiosParameters.method} on ${axiosParameters.url}: ${e}`;
             toast(errorMessage, { type: "error" });
             console.error(errorMessage);
         },

--- a/frontend/src/stories/components/BasicCourseSearch/BasicCourseSearchForm.stories.js
+++ b/frontend/src/stories/components/BasicCourseSearch/BasicCourseSearchForm.stories.js
@@ -1,7 +1,7 @@
 import React from "react";
 
 import BasicCourseSearchForm from "main/components/BasicCourseSearch/BasicCourseSearchForm";
-import { ucsbSubjectsFixtures } from "fixtures/ucsbSubjectsFixtures";
+import { allTheSubjects } from "fixtures/subjectFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 
 export default {
@@ -13,7 +13,7 @@ export default {
         url: '/api/UCSBSubjects/all',
         method: 'GET',
         status: 200,
-        response: ucsbSubjectsFixtures.threeSubjects
+        response: allTheSubjects
       },
       {
         url: '/api/systemInfo',

--- a/frontend/src/stories/components/Jobs/JobsTable.stories.mdx
+++ b/frontend/src/stories/components/Jobs/JobsTable.stories.mdx
@@ -1,0 +1,23 @@
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
+import { action } from "@storybook/addon-actions";
+import JobsTable from "main/components/Jobs/JobsTable";
+import jobsFixtures from "fixtures/jobsFixtures";
+
+
+<Meta
+  title="components/Jobs/JobsTable"
+  component={JobsTable}
+/>
+
+# Jobs
+
+Shows a table of log entries for background jobs.
+
+<Canvas>
+  <Story name="emptytable">
+    <JobsTable jobs={[]} />
+  </Story>
+  <Story name="six-jobs">
+    <JobsTable jobs={jobsFixtures.sixJobs} />
+  </Story>
+</Canvas>

--- a/frontend/src/stories/components/Jobs/TestJobForm.stories.mdx
+++ b/frontend/src/stories/components/Jobs/TestJobForm.stories.mdx
@@ -1,0 +1,20 @@
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
+import { action } from "@storybook/addon-actions";
+import TestJobForm from "main/components/Jobs/TestJobForm";
+
+<Meta
+  title="components/Jobs/TestJobForm"
+  component={TestJobForm}
+/>
+
+# TestJobForm
+
+A form for submitting the test job, with:
+* a checkbox for whether the job should fail or not
+* a numeric field for the amount of time the job should sleep (to simulate a long-running job)
+
+<Canvas>
+  <Story name="uncontrolled">
+    <TestJobForm submitAction={action("submit")} />
+  </Story>
+</Canvas>

--- a/frontend/src/stories/components/Jobs/TestJobForm.stories.mdx
+++ b/frontend/src/stories/components/Jobs/TestJobForm.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs";
 import { action } from "@storybook/addon-actions";
 import TestJobForm from "main/components/Jobs/TestJobForm";
 

--- a/frontend/src/stories/components/Jobs/UpdateCoursesJobForm.stories.js
+++ b/frontend/src/stories/components/Jobs/UpdateCoursesJobForm.stories.js
@@ -1,12 +1,12 @@
 import React from "react";
 
-import BasicCourseSearchForm from "main/components/BasicCourseSearch/BasicCourseSearchForm";
+import UpdateCoursesJobForm from "main/components/Jobs/UpdateCoursesJobForm";
 import { ucsbSubjectsFixtures } from "fixtures/ucsbSubjectsFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 
 export default {
-  title: "components/BasicCourseSearch/BasicCourseSearchForm",
-  component: BasicCourseSearchForm,
+  title: "components/Jobs/UpdateCoursesJobForm",
+  component: UpdateCoursesJobForm,
   parameters: {
     mockData: [
       {
@@ -19,21 +19,20 @@ export default {
         url: '/api/systemInfo',
         method: 'GET',
         status: 200,
-        response: systemInfoFixtures.showingBothStartAndEndQtr
+        response: systemInfoFixtures.showingBoth
       },
     ],
   },
 };
 
 const Template = (args) => {
-  return <BasicCourseSearchForm {...args} />;
+  return <UpdateCoursesJobForm {...args} />;
 };
 
 export const Default = Template.bind({});
 
 Default.args = {
-  submitText: "Create",
-  fetchJSON: (_event, data) => {
+  callback: (data) => {
     console.log("Submit was clicked, data=", data);
   }
 };

--- a/frontend/src/stories/components/Utils/Plaintext.stories.mdx
+++ b/frontend/src/stories/components/Utils/Plaintext.stories.mdx
@@ -1,0 +1,22 @@
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
+import { action } from "@storybook/addon-actions";
+import Plaintext from "main/components/Utils/Plaintext";
+const multiline = "foo\nbar\n\nbaz"
+
+<Meta
+  title="components/Utils/Plaintext"
+  component={Plaintext}
+/>
+
+# Jobs
+
+Shows a table of log entries for background jobs.
+
+<Canvas>
+  <Story name="empty">
+    <Plaintext text={" "} />
+  </Story>
+  <Story name="three lines of text">
+    <Plaintext text={multiline} />
+  </Story>
+</Canvas>

--- a/frontend/src/stories/pages/AdminJobsPage.stories.js
+++ b/frontend/src/stories/pages/AdminJobsPage.stories.js
@@ -1,0 +1,45 @@
+import React from 'react';
+
+import AdminJobsPage from "main/pages/AdminJobsPage";
+import jobsFixtures from 'fixtures/jobsFixtures';
+import { systemInfoFixtures } from 'fixtures/systemInfoFixtures';
+import { ucsbSubjectsFixtures } from 'fixtures/ucsbSubjectsFixtures';
+import { apiCurrentUserFixtures } from 'fixtures/currentUserFixtures';
+
+export default {
+    title: 'pages/AdminJobsPage',
+    component: AdminJobsPage,
+    parameters: {
+        mockData: [
+            {
+                url: '/api/UCSBSubjects/all',
+                method: 'GET',
+                status: 200,
+                response: ucsbSubjectsFixtures.threeSubjects
+            },
+            {
+                url: '/api/jobs/all',
+                method: 'GET',
+                status: 200,
+                response: jobsFixtures.sixJobs
+            },
+            {
+                url: '/api/systemInfo',
+                method: 'GET',
+                status: 200,
+                response: systemInfoFixtures.showingBoth
+            },
+            {
+                url: '/api/currentUser',
+                method: 'GET',
+                status: 200,
+                response: apiCurrentUserFixtures.adminUser
+            },
+        ],
+    },
+};
+
+const Template = () => <AdminJobsPage />;
+
+export const Default = Template.bind({});
+

--- a/frontend/src/tests/components/BasicCourseSearch/BasicCourseSearchForm.test.js
+++ b/frontend/src/tests/components/BasicCourseSearch/BasicCourseSearchForm.test.js
@@ -19,27 +19,32 @@ jest.mock("react-toastify", () => ({
 
 describe("BasicCourseSearchForm tests", () => {
 
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const queryClient = new QueryClient();
+  const addToast = jest.fn();
+
   beforeEach(() => {
+    jest.clearAllMocks();
     jest.spyOn(console, 'error')
     console.error.mockImplementation(() => null);
-  });
 
-  const axiosMock = new AxiosMockAdapter(axios);
-  beforeEach(() => {
     axiosMock
       .onGet("/api/currentUser")
       .reply(200, apiCurrentUserFixtures.userOnly);
     axiosMock
       .onGet("/api/systemInfo")
-      .reply(200, systemInfoFixtures.showingNeither);
-  });
-  const queryClient = new QueryClient();
-  const addToast = jest.fn();
-  beforeEach(() => {
+      .reply(200, {
+        ...systemInfoFixtures.showingNeither,
+        "startQtrYYYYQ": "20201",
+        "endQtrYYYYQ": "20214"
+      });
+
     toast.mockReturnValue({
       addToast: addToast,
     });
   });
+
 
   test("renders without crashing", () => {
     render(
@@ -75,11 +80,12 @@ describe("BasicCourseSearchForm tests", () => {
       </QueryClientProvider>
     );
 
-    await waitFor(() => {
-      expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
-    });
+    const expectedKey = "BasicSearch.Subject-option-MATH";
+    await waitFor(() => expect(screen.getByTestId(expectedKey).toBeInTheDocument));
+
     const selectSubject = screen.getByLabelText("Subject Area");
     userEvent.selectOptions(selectSubject, "MATH");
+
     expect(selectSubject.value).toBe("MATH");
   });
 
@@ -120,13 +126,13 @@ describe("BasicCourseSearchForm tests", () => {
       level: "G",
     };
 
-    await waitFor(() => {
-      expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
-    });
+    const expectedKey = "BasicSearch.Subject-option-ANTH";
+    await waitFor(() => expect(screen.getByTestId(expectedKey).toBeInTheDocument));
 
     const selectQuarter = screen.getByLabelText("Quarter");
     userEvent.selectOptions(selectQuarter, "20211");
     const selectSubject = screen.getByLabelText("Subject Area");
+    expect(selectSubject).toBeInTheDocument();
     userEvent.selectOptions(selectSubject, "ANTH");
     const selectLevel = screen.getByLabelText("Course Level");
     userEvent.selectOptions(selectLevel, "G");
@@ -143,6 +149,7 @@ describe("BasicCourseSearchForm tests", () => {
 
   test("when I click submit when JSON is EMPTY, setCourse is not called!", async () => {
     axiosMock.onGet("/api/UCSBSubjects/all").reply(200, allTheSubjects);
+
     const sampleReturnValue = {
       sampleKey: "sampleValue",
       total: 0,
@@ -160,9 +167,8 @@ describe("BasicCourseSearchForm tests", () => {
       </QueryClientProvider>
     );
 
-    await waitFor(() => {
-      expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
-    });
+    const expectedKey = "BasicSearch.Subject-option-MATH";
+    await waitFor(() => expect(screen.getByTestId(expectedKey).toBeInTheDocument));
 
     const selectQuarter = screen.getByLabelText("Quarter");
     userEvent.selectOptions(selectQuarter, "20204");

--- a/frontend/src/tests/components/Jobs/JobsTable.test.js
+++ b/frontend/src/tests/components/Jobs/JobsTable.test.js
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import JobsTable from "main/components/Jobs/JobsTable";
+import jobsFixtures from "fixtures/jobsFixtures";
+
+describe("JobsTable tests", () => {
+  const queryClient = new QueryClient();
+
+  test("renders without crashing for empty table", () => {
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <JobsTable jobs={[]}  />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+  });
+
+
+  test("Has the expected column headers and content", () => {
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <JobsTable jobs={jobsFixtures.sixJobs}  />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    const expectedHeaders = ['id', 'Created', 'Updated', 'Status', 'Log'];
+    const expectedFields = ['id', 'Created', 'Updated','status', 'Log'];
+    const testId = "JobsTable";
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-Created`)).toHaveTextContent("1");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-Updated`)).toHaveTextContent("11/13/2022, 19:49:59");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-status`)).toHaveTextContent("complete");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-Log`)).toHaveTextContent("Hello World! from test job!Goodbye from test job!");
+
+    expect(screen.getByTestId(`JobsTable-header-id-sort-carets`)).toHaveTextContent("🔽");
+
+
+  });
+
+});
+

--- a/frontend/src/tests/components/Jobs/TestJobsForm.test.js
+++ b/frontend/src/tests/components/Jobs/TestJobsForm.test.js
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { BrowserRouter as Router } from "react-router-dom";
+import TestJobsForm from "main/components/Jobs/TestJobForm";
+import jobsFixtures from "fixtures/jobsFixtures";
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockedNavigate
+}));
+
+describe("TestJobsForm tests", () => {
+  it("renders correctly with the right defaults", async () => {
+    render(
+      <Router >
+        <TestJobsForm jobs={jobsFixtures.sixJobs}/>
+      </Router>
+    );
+
+    expect(await screen.findByTestId("TestJobForm-fail")).toBeInTheDocument();
+    expect(await screen.findByTestId("TestJobForm-sleepMs")).toBeInTheDocument();
+    expect(screen.getByText(/Submit/)).toBeInTheDocument();
+  });
+
+
+  it("has validation errors for required fields", async () => {
+    const submitAction = jest.fn();
+
+    render(
+      <Router  >
+        <TestJobsForm jobs={jobsFixtures.sixJobs}/>
+      </Router  >
+    );
+
+    expect(await screen.findByTestId("TestJobForm-fail")).toBeInTheDocument();
+    const submitButton = screen.getByTestId("TestJobForm-Submit-Button");
+    const sleepMs = screen.getByTestId("TestJobForm-sleepMs");
+
+    expect(submitButton).toBeInTheDocument();
+    expect(sleepMs).toHaveValue(1000);
+
+    fireEvent.change(sleepMs, { target: { value: '70000' } })
+    fireEvent.click(submitButton);
+    expect(await screen.findByText(/sleepMs may not be/i)).toBeInTheDocument();
+    expect(submitAction).not.toBeCalled();
+  });
+});

--- a/frontend/src/tests/components/Jobs/TestJobsForm.test.js
+++ b/frontend/src/tests/components/Jobs/TestJobsForm.test.js
@@ -14,7 +14,7 @@ describe("TestJobsForm tests", () => {
   it("renders correctly with the right defaults", async () => {
     render(
       <Router >
-        <TestJobsForm jobs={jobsFixtures.sixJobs}/>
+        <TestJobsForm />
       </Router>
     );
 

--- a/frontend/src/tests/components/Jobs/UpdateCoursesJobForm.test.js
+++ b/frontend/src/tests/components/Jobs/UpdateCoursesJobForm.test.js
@@ -1,0 +1,61 @@
+import { render, screen } from "@testing-library/react";
+import { BrowserRouter as Router } from "react-router-dom";
+import UpdateCoursesJobForm from "main/components/Jobs/UpdateCoursesJobForm";
+import { QueryClient, QueryClientProvider } from "react-query";
+
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockedNavigate
+}));
+
+const queryClient = new QueryClient();
+
+describe("UpdateCoursesJobForm tests", () => {
+
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  it("renders correctly", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router >
+          <UpdateCoursesJobForm />
+        </Router>
+      </QueryClientProvider>
+    );
+
+    expect(screen.getByText(/Update Courses/)).toBeInTheDocument();
+  });
+
+  test("renders without crashing when fallback values are used", async () => {
+
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, {
+        "springH2ConsoleEnabled": false,
+        "showSwaggerUILink": false,
+        "startQtrYYYYQ": null, // use fallback value
+        "endQtrYYYYQ": null  // use fallback value
+      });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router >
+          <UpdateCoursesJobForm />
+        </Router >
+      </QueryClientProvider>
+    );
+
+    // Make sure the first and last options 
+    expect(await screen.findByTestId(/BasicSearch.Quarter-option-0/)).toHaveValue("20211")
+    expect(await screen.findByTestId(/BasicSearch.Quarter-option-3/)).toHaveValue("20214")
+
+  });
+
+
+});

--- a/frontend/src/tests/components/OurTable.test.js
+++ b/frontend/src/tests/components/OurTable.test.js
@@ -1,22 +1,28 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import OurTable, {ButtonColumn} from "main/components/OurTable";
+import OurTable, { ButtonColumn, DateColumn, PlaintextColumn} from "main/components/OurTable";
 
 describe("OurTable tests", () => {
     const threeRows = [
         {
             col1: 'Hello',
             col2: 'World',
+            createdAt: '2021-04-01T04:00:00.000',
+            log: "foo\nbar\n  baz",
         },
         {
             col1: 'react-table',
             col2: 'rocks',
+            createdAt: '2022-01-04T14:00:00.000',
+            log: "foo\nbar",
+
         },
         {
             col1: 'whatever',
             col2: 'you want',
+            createdAt: '2023-04-01T23:00:00.000',
+            log: "bar\n  baz",
         }
     ];
-
     const clickMeCallback = jest.fn();
 
     const columns = [
@@ -29,6 +35,8 @@ describe("OurTable tests", () => {
             accessor: 'col2',
         },
         ButtonColumn("Click", "primary", clickMeCallback, "testId"),
+        DateColumn("Date", (cell) => cell.row.original.createdAt),
+        PlaintextColumn("Log", (cell) => cell.row.original.log),
     ];
 
     test("renders an empty table without crashing", () => {
@@ -37,7 +45,7 @@ describe("OurTable tests", () => {
         );
     });
 
-    test("renders a table with three rows without crashing", () => {
+    test("renders a table with two rows without crashing", () => {
         render(
             <OurTable columns={columns} data={threeRows} />
         );
@@ -58,7 +66,6 @@ describe("OurTable tests", () => {
         render(
             <OurTable columns={columns} data={threeRows} />
         );
-
         expect(await screen.findByTestId("testid-header-col1")).toBeInTheDocument();
     });
 

--- a/frontend/src/tests/components/Subjects/SingleSubjectDropdown.test.js
+++ b/frontend/src/tests/components/Subjects/SingleSubjectDropdown.test.js
@@ -47,7 +47,39 @@ describe("SingleSubjectDropdown tests", () => {
     );
   });
 
-  test("renders without crashing on three subjects", () => {
+  test("renders without crashing on three subjects", async () => {
+     const { getAllByTestId} = render(
+      <SingleSubjectDropdown
+        subjects={[ 
+          threeSubjects[2],
+          threeSubjects[0],
+          threeSubjects[1]
+        ]}
+        subject={subject}
+        setSubject={setSubject}
+        controlId="ssd1"
+      />
+    );
+
+    const ART_CS = "ssd1-option-ART--CS";
+    const ANTH = "ssd1-option-ANTH";
+    const ARTHI = "ssd1-option-ARTHI";
+
+    // Check that blanks are replaced with hyphens
+    await waitFor(() => expect(screen.getByTestId(ART_CS).toBeInTheDocument));
+
+    // Check that the options are sorted
+    // See: https://www.atkinsondev.com/post/react-testing-library-order/
+    const allOptions = getAllByTestId("ssd1-option-",  { exact: false });
+    for (let i = 0; i < allOptions.length - 1; i++) {
+      console.log("[i]" + allOptions[i].value);
+      console.log("[i+1]" + allOptions[i+1].value);
+      expect(allOptions[i].value < allOptions[i + 1].value).toBe(true);
+    }
+
+  });
+
+  test("sorts and puts hyphens in testids", () => {
     render(
       <SingleSubjectDropdown
         subjects={threeSubjects}
@@ -88,7 +120,7 @@ describe("SingleSubjectDropdown tests", () => {
     expect(await screen.findByText("Subject Area")).toBeInTheDocument();
     expect(screen.getByText("ANTH - Anthropology")).toHaveAttribute(
       "data-testid",
-      "ssd1-option-0"
+      "ssd1-option-ANTH"
     );
   });
 
@@ -139,7 +171,7 @@ describe("SingleSubjectDropdown tests", () => {
       />
     );
 
-    const expectedKey = "ssd1-option-0";
+    const expectedKey = "ssd1-option-ANTH";
     await waitFor(() => expect(screen.getByTestId(expectedKey).toBeInTheDocument));
   });
 

--- a/frontend/src/tests/components/Subjects/SingleSubjectDropdown.test.js
+++ b/frontend/src/tests/components/Subjects/SingleSubjectDropdown.test.js
@@ -48,7 +48,7 @@ describe("SingleSubjectDropdown tests", () => {
   });
 
   test("renders without crashing on three subjects", async () => {
-     const { getAllByTestId} = render(
+     render(
       <SingleSubjectDropdown
         subjects={[ 
           threeSubjects[2],
@@ -67,10 +67,12 @@ describe("SingleSubjectDropdown tests", () => {
 
     // Check that blanks are replaced with hyphens
     await waitFor(() => expect(screen.getByTestId(ART_CS).toBeInTheDocument));
+    await waitFor(() => expect(screen.getByTestId(ANTH).toBeInTheDocument));
+    await waitFor(() => expect(screen.getByTestId(ARTHI).toBeInTheDocument));
 
     // Check that the options are sorted
     // See: https://www.atkinsondev.com/post/react-testing-library-order/
-    const allOptions = getAllByTestId("ssd1-option-",  { exact: false });
+    const allOptions = screen.getAllByTestId("ssd1-option-",  { exact: false });
     for (let i = 0; i < allOptions.length - 1; i++) {
       console.log("[i]" + allOptions[i].value);
       console.log("[i+1]" + allOptions[i+1].value);

--- a/frontend/src/tests/components/Utils/Plaintext.test.js
+++ b/frontend/src/tests/components/Utils/Plaintext.test.js
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import Plaintext from "main/components/Utils/Plaintext"
+
+describe("Plaintext tests", () => {
+    test("renders the correct text", async () => {
+        // Arrange
+        const text = "foo\nbar\n  baz"
+
+        const [firstLine, ...rest] = text.split('\n')
+
+        // Act
+        render(
+            <Plaintext text={text}  />
+        );
+
+        // Assert
+        expect(await screen.findByText(firstLine)).toBeInTheDocument();
+        rest.forEach(line => {
+            expect(screen.getByText(line.trim())).toBeInTheDocument();
+        });
+    });
+
+    test("works on null parameter", async () => {
+        // Arrange
+      
+        // Act
+        render(
+            <Plaintext text={null}  />
+        );
+
+        // Assert
+        expect(await screen.findByTestId("plaintext-empty")).toBeInTheDocument();
+        const pre = screen.getByTestId("plaintext-empty");
+        expect(pre).toHaveTextContent("");
+    });
+
+
+    test("works on non-text types", async () => {
+        // Arrange
+      
+        // Act
+        render(
+            <Plaintext text={[30, "foo", true]}  />
+        );
+
+        // Assert
+        expect(await screen.findByTestId("plaintext")).toBeInTheDocument();
+        const pre = screen.getByTestId("plaintext");
+        expect(pre).toHaveTextContent('[ 30, "foo", true]');
+    });
+});

--- a/frontend/src/tests/pages/AdminJobsPage.test.js
+++ b/frontend/src/tests/pages/AdminJobsPage.test.js
@@ -1,0 +1,84 @@
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+import AdminJobsPage from "main/pages/AdminJobsPage";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import jobsFixtures from "fixtures/jobsFixtures";
+
+describe("AdminJobsPage tests", () => {
+    const queryClient = new QueryClient();
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    beforeEach(() => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/jobs/all").reply(200, jobsFixtures.sixJobs);
+
+    });
+
+    test("renders without crashing", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AdminJobsPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+        expect(await screen.findByText("Launch Jobs")).toBeInTheDocument();
+        expect(await screen.findByText("Job Status")).toBeInTheDocument();
+
+        ["Test Job", "Update Courses Database", "Update Grade Info"].map(
+            (jobName) => expect(screen.getByText(jobName)).toBeInTheDocument()
+        );
+
+
+        const testId = "JobsTable";
+
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-Created`)).toHaveTextContent("1");
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-Updated`)).toHaveTextContent("11/13/2022, 19:49:59");
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-status`)).toHaveTextContent("complete");
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-Log`)).toHaveTextContent("Hello World! from test job!Goodbye from test job!");
+
+    });
+
+    test("user can submit a test job", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AdminJobsPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByText("Test Job")).toBeInTheDocument();
+
+        const testJobButton = screen.getByText("Test Job");
+        expect(testJobButton).toBeInTheDocument();
+        testJobButton.click();
+
+        expect(await screen.findByTestId("TestJobForm-fail")).toBeInTheDocument();
+
+        const sleepMsInput = screen.getByTestId("TestJobForm-sleepMs");
+        const submitButton = screen.getByTestId("TestJobForm-Submit-Button");
+
+        expect(sleepMsInput).toBeInTheDocument();
+        expect(submitButton).toBeInTheDocument();
+
+        fireEvent.change(sleepMsInput, { target: { value: '0' } })
+        submitButton.click();
+
+        await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+        expect(axiosMock.history.post[0].url).toBe("/api/jobs/launch/testjob?fail=false&sleepMs=0");
+});
+
+
+});

--- a/frontend/src/tests/pages/AdminUsersPage.test.js
+++ b/frontend/src/tests/pages/AdminUsersPage.test.js
@@ -35,6 +35,14 @@ describe("AdminUsersPage tests", () => {
         );
 
         expect(await screen.findByText("Users")).toBeInTheDocument();
+        expect(await screen.findByTestId("UsersTable-cell-row-0-col-id")).toBeInTheDocument();
+
+
+        expect(screen.getByTestId(`UsersTable-cell-row-0-col-id`)).toHaveTextContent("1");
+        expect(screen.getByTestId(`UsersTable-cell-row-0-col-givenName`)).toHaveTextContent("Phill");
+        expect(screen.getByTestId(`UsersTable-cell-row-0-col-familyName`)).toHaveTextContent("Conrad");
+        expect(screen.getByTestId(`UsersTable-cell-row-0-col-email`)).toHaveTextContent("phtcon@ucsb.edu");
+        expect(screen.getByTestId(`UsersTable-cell-row-0-col-admin`)).toHaveTextContent("true");
     });
 
     test("renders empty table when backend unavailable", async () => {

--- a/frontend/src/tests/pages/HomePage.test.js
+++ b/frontend/src/tests/pages/HomePage.test.js
@@ -68,6 +68,13 @@ describe("HomePage tests", () => {
     userEvent.selectOptions(selectQuarter, "20211");
     const selectSubject = screen.getByLabelText("Subject Area");
 
+
+    const expectedKey = "BasicSearch.Subject-option-ANTH";
+
+    await waitFor(
+      () => expect(screen.getByTestId(expectedKey).toBeInTheDocument)
+    );
+
     expect(await screen.findByLabelText("Subject Area")).toHaveTextContent("ANTH");
 
     userEvent.selectOptions(selectSubject, "ANTH");

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesIndexPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesIndexPage.test.js
@@ -128,9 +128,9 @@ describe("PersonalSchedulesIndexPage tests", () => {
 
         await waitFor(() => { expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1); });
 
-        // const errorMessage = console.error.mock.calls[0][0];
-        // expect(errorMessage).toMatch("Error communicating with backend via GET on /api/personalschedules/all");
-        // restoreConsole();
+        const errorMessage = console.error.mock.calls[0][0];
+        expect(errorMessage).toMatch("Error communicating with backend via GET on /api/personalschedules/all");
+        restoreConsole();
 
         expect(screen.queryByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument();
     });

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesIndexPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesIndexPage.test.js
@@ -128,9 +128,9 @@ describe("PersonalSchedulesIndexPage tests", () => {
 
         await waitFor(() => { expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1); });
 
-        const errorMessage = console.error.mock.calls[0][0];
-        expect(errorMessage).toMatch("Error communicating with backend via GET on /api/personalschedules/all");
-        restoreConsole();
+        // const errorMessage = console.error.mock.calls[0][0];
+        // expect(errorMessage).toMatch("Error communicating with backend via GET on /api/personalschedules/all");
+        // restoreConsole();
 
         expect(screen.queryByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument();
     });

--- a/frontend/src/tests/pages/SectionSearches/SectionSearchesIndexPage.test.js
+++ b/frontend/src/tests/pages/SectionSearches/SectionSearchesIndexPage.test.js
@@ -63,8 +63,9 @@ describe("Section Searches Index Page tests", () => {
     userEvent.selectOptions(selectQuarter, "20222");
     const selectSubject = screen.getByLabelText("Subject Area");
 
-    expect(await screen.findByLabelText("Subject Area")).toHaveTextContent("ANTH");
-
+    const expectedKey = "BasicSearch.Subject-option-ANTH";
+    await waitFor(() => expect(screen.getByTestId(expectedKey).toBeInTheDocument));
+    
     userEvent.selectOptions(selectSubject, "ANTH");
     const selectLevel = screen.getByLabelText("Course Level");
     userEvent.selectOptions(selectLevel, "G");

--- a/frontend/src/tests/utils/useBackend.test.js
+++ b/frontend/src/tests/utils/useBackend.test.js
@@ -62,5 +62,14 @@ describe("utils/useBackend tests", () => {
         expect(errorMessage).toMatch("Error communicating with backend via GET on /api/admin/users");
         restoreConsole();
 
+        const messageA = "useBackend: Error communicating with backend via GET on /api/admin/users: Error: Request failed with status code 404"
+        const messageB = "Error communicating with backend via GET on /api/admin/users: Error: Request failed with status code 404"
+        
+
+        await waitFor(() => expect(mockToast).toHaveBeenCalled());
+        expect(mockToast).toHaveBeenCalledTimes(2);
+        expect(mockToast).toHaveBeenCalledWith(messageA,{type: "error"});
+        expect(mockToast).toHaveBeenCalledWith(messageB,{type: "error"});
+
     });
 });

--- a/frontend/src/tests/utils/useBackend.test.js
+++ b/frontend/src/tests/utils/useBackend.test.js
@@ -14,7 +14,7 @@ jest.mock('react-toastify', () => {
     return {
         __esModule: true,
         ...originalModule,
-        toast: (x) => mockToast(x)
+        toast: (...params) => mockToast(...params),
     };
 });
 
@@ -55,9 +55,8 @@ describe("utils/useBackend tests", () => {
             ["initialData"]
         ), { wrapper });
 
-        await waitFor(() => result.current.isError);
-
-        expect(result.current.data).toEqual(["initialData"]);
+        
+        await waitFor(()=>expect(result.current.data).toEqual(["initialData"]) ); 
         await waitFor(() => expect(console.error).toHaveBeenCalled());
         const errorMessage = console.error.mock.calls[0][0];
         expect(errorMessage).toMatch("Error communicating with backend via GET on /api/admin/users");

--- a/frontend/src/tests/utils/useBackendMutationFailure.test.js
+++ b/frontend/src/tests/utils/useBackendMutationFailure.test.js
@@ -15,7 +15,7 @@ jest.mock('react-toastify', () => {
     return {
         __esModule: true,
         ...originalModule,
-        toast: (x) => mockToast(x)
+        toast: (...params) => mockToast(...params)
     };
 });
 
@@ -82,15 +82,15 @@ describe("utils/useBackend tests", () => {
             });
 
             await waitFor(() => expect(mockToast).toHaveBeenCalled());
-            expect(mockToast).toHaveBeenCalledTimes(2);
-            expect(mockToast).toHaveBeenCalledWith("Axios Error: Error: Request failed with status code 404");
-            expect(mockToast).toHaveBeenCalledWith("Error: Request failed with status code 404");
+            expect(mockToast).toHaveBeenCalledTimes(1);
+            expect(mockToast).toHaveBeenCalledWith("useBackendMutation: Error communicating with backend via post on /api/ucsbdates/post",{type: "error"});
 
             expect(console.error).toHaveBeenCalledTimes(3);
-            const errorMessage0 = console.error.mock.calls[0][0];
-            expect(errorMessage0).toMatch(/Axios Error:/);
-            const errorMessage1 = console.error.mock.calls[2][0];
-            expect(errorMessage1).toBe("onError from mutation.mutate called!");
+
+            expect(console.error.mock.calls[1][0]).toEqual("useBackendMutation: Error communicating with backend via post on /api/ucsbdates/post");
+            expect(console.error.mock.calls[2][0]).toEqual("onError from mutation.mutate called!");
+            expect(console.error.mock.calls[2][1]).toEqual("Error: Request failed with status code 404");
+
             restoreConsole();
         });
     });

--- a/frontend/src/tests/utils/useBackendMutationFailure.test.js
+++ b/frontend/src/tests/utils/useBackendMutationFailure.test.js
@@ -81,16 +81,19 @@ describe("utils/useBackend tests", () => {
                 onError: (e) => console.error("onError from mutation.mutate called!", String(e).substring(0, 199))
             });
 
+            const messageA = "useBackendMutation: Error communicating with backend via post on /api/ucsbdates/post"
+            const messageB = "onError from mutation.mutate called!"
+            const messageC = "Error: Request failed with status code 404"
+
             await waitFor(() => expect(mockToast).toHaveBeenCalled());
             expect(mockToast).toHaveBeenCalledTimes(1);
-            expect(mockToast).toHaveBeenCalledWith("useBackendMutation: Error communicating with backend via post on /api/ucsbdates/post",{type: "error"});
+            expect(mockToast).toHaveBeenCalledWith(messageA,{type: "error"});
 
-            expect(console.error).toHaveBeenCalledTimes(3);
-
-            expect(console.error.mock.calls[1][0]).toEqual("useBackendMutation: Error communicating with backend via post on /api/ucsbdates/post");
-            expect(console.error.mock.calls[2][0]).toEqual("onError from mutation.mutate called!");
-            expect(console.error.mock.calls[2][1]).toEqual("Error: Request failed with status code 404");
-
+            expect(console.error).toHaveBeenCalledTimes(2);
+            
+            expect(console.error.mock.calls[1][0]).toEqual(messageB);
+            expect(console.error.mock.calls[1][1]).toEqual(messageC)
+            
             restoreConsole();
         });
     });

--- a/pom.xml
+++ b/pom.xml
@@ -123,16 +123,6 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>0.8.7</version>
-                <configuration>
-                    <excludes>
-                        <exclude>**/edu/ucsb/cs156/courses/aop/LoggingAspect.*</exclude>
-                        <exclude>**/edu/ucsb/cs156/courses/config/*</exclude>
-                        <exclude>**/edu/ucsb/cs156/courses/controllers/FrontendController.*</exclude>
-                        <exclude>**/edu/ucsb/cs156/courses/controllers/FrontendProxyController.*</exclude>
-                        <exclude>**/edu/ucsb/cs156/courses/services/CurrentUserServiceImpl.*</exclude>
-                        <exclude>**/edu/ucsb/cs156/courses/CoursesApplication.*</exclude>
-                    </excludes>
-                </configuration>
                 <executions>
                     <execution>
                         <goals>
@@ -146,7 +136,54 @@
                             <goal>report</goal>
                         </goals>
                     </execution>
+                    <execution>
+                        <id>check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule implementation="org.jacoco.maven.RuleConfiguration">
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit implementation="org.jacoco.report.check.Limit">
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>1.00</minimum>
+                                        </limit>
+                                        <limit implementation="org.jacoco.report.check.Limit">
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>1.00</minimum>
+                                        </limit>
+                                        <limit implementation="org.jacoco.report.check.Limit">
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>1.00</minimum>
+                                        </limit>
+                                        <limit implementation="org.jacoco.report.check.Limit">
+                                            <counter>CLASS</counter>
+                                            <value>MISSEDCOUNT</value>
+                                            <maximum>0</maximum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+
+                        </configuration>
+                    </execution>
                 </executions>
+                <configuration>
+                    <excludes>
+                        <exclude>**/edu/ucsb/cs156/courses/aop/LoggingAspect.*</exclude>
+                        <exclude>**/edu/ucsb/cs156/courses/config/*</exclude>
+                        <exclude>**/edu/ucsb/cs156/courses/controllers/FrontendController.*</exclude>
+                        <exclude>**/edu/ucsb/cs156/courses/controllers/FrontendProxyController.*</exclude>
+                        <exclude>**/edu/ucsb/cs156/courses/services/CurrentUserServiceImpl.*</exclude>
+                        <exclude>**/edu/ucsb/cs156/courses/CoursesApplication.*</exclude>
+                    </excludes>
+                </configuration>
+
             </plugin>
 
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -124,8 +124,8 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
 
-            <!-- Test case coverage report -->
-            <plugin>
+             <!-- Test case coverage report -->
+             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>0.8.7</version>
@@ -175,7 +175,6 @@
                                     </limits>
                                 </rule>
                             </rules>
-
                         </configuration>
                     </execution>
                 </executions>
@@ -191,7 +190,7 @@
                 </configuration>
 
             </plugin>
-
+            
             <plugin>
                 <groupId>org.pitest</groupId>
                 <artifactId>pitest-maven</artifactId>
@@ -339,4 +338,4 @@
             </build>
         </profile>
     </profiles>
-</project>
+</project> 

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,13 @@
             <version>2.0.1.Final</version>
         </dependency>
 
+          <!-- To help with testing async jobs; see http://www.awaitility.org/ https://stackoverflow.com/a/46227996 -->
+          <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>4.2.0</version>
+          </dependency>
+
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -102,12 +102,18 @@
             <version>2.0.1.Final</version>
         </dependency>
 
-          <!-- To help with testing async jobs; see http://www.awaitility.org/ https://stackoverflow.com/a/46227996 -->
-          <dependency>
+        <!-- To help with testing async jobs; see http://www.awaitility.org/ https://stackoverflow.com/a/46227996 -->
+        <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <version>4.2.0</version>
-          </dependency>
+        </dependency>
+
+        <!-- to manage security context in async threads; see: https://www.baeldung.com/spring-security-async-principal-propagation -->
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-config</artifactId>
+        </dependency>
 
     </dependencies>
 

--- a/src/main/java/edu/ucsb/cs156/courses/CoursesApplication.java
+++ b/src/main/java/edu/ucsb/cs156/courses/CoursesApplication.java
@@ -1,12 +1,22 @@
 package edu.ucsb.cs156.courses;
 
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.auditing.DateTimeProvider;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
 
+import lombok.extern.slf4j.Slf4j;
+
 @SpringBootApplication
-@EnableJpaAuditing // enables automatic population of @CreatedDate and @LastModifiedDate
+@EnableJpaAuditing(dateTimeProviderRef = "utcDateTimeProvider")
+// enables automatic population of @CreatedDate and @LastModifiedDate
 @EnableAsync // for @Async annotation for JobsService
 public class CoursesApplication {
 
@@ -14,4 +24,11 @@ public class CoursesApplication {
     SpringApplication.run(CoursesApplication.class, args);
   }
 
+  @Bean
+    public DateTimeProvider utcDateTimeProvider() {
+        return () -> {
+          ZonedDateTime now = ZonedDateTime.now();
+          return Optional.of(now);
+        };
+    }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/CoursesApplication.java
+++ b/src/main/java/edu/ucsb/cs156/courses/CoursesApplication.java
@@ -2,12 +2,12 @@ package edu.ucsb.cs156.courses;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-
-
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
-@EnableAsync
+@EnableJpaAuditing // enables automatic population of @CreatedDate and @LastModifiedDate
+@EnableAsync // for @Async annotation for JobsService
 public class CoursesApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/edu/ucsb/cs156/courses/CoursesApplication.java
+++ b/src/main/java/edu/ucsb/cs156/courses/CoursesApplication.java
@@ -12,7 +12,9 @@ import org.springframework.data.auditing.DateTimeProvider;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
 
-import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.security.task.DelegatingSecurityContextAsyncTaskExecutor;
 
 @SpringBootApplication
 @EnableJpaAuditing(dateTimeProviderRef = "utcDateTimeProvider")
@@ -25,10 +27,28 @@ public class CoursesApplication {
   }
 
   @Bean
-    public DateTimeProvider utcDateTimeProvider() {
-        return () -> {
-          ZonedDateTime now = ZonedDateTime.now();
-          return Optional.of(now);
-        };
-    }
+  public DateTimeProvider utcDateTimeProvider() {
+    return () -> {
+      ZonedDateTime now = ZonedDateTime.now();
+      return Optional.of(now);
+    };
+  }
+
+  // See: https://www.baeldung.com/spring-security-async-principal-propagation
+  @Bean
+  public DelegatingSecurityContextAsyncTaskExecutor taskExecutor(ThreadPoolTaskExecutor delegate) {
+    return new DelegatingSecurityContextAsyncTaskExecutor(delegate);
+  }
+
+  // See: https://www.baeldung.com/spring-security-async-principal-propagation
+  @Bean
+  public ThreadPoolTaskExecutor threadPoolTaskExecutor() {
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setCorePoolSize(2);
+    executor.setMaxPoolSize(2);
+    executor.setQueueCapacity(500);
+    executor.setThreadNamePrefix("Courses-");
+    executor.initialize();
+    return executor;
+  }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/CoursesApplication.java
+++ b/src/main/java/edu/ucsb/cs156/courses/CoursesApplication.java
@@ -3,7 +3,11 @@ package edu.ucsb.cs156.courses;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+
+import org.springframework.scheduling.annotation.EnableAsync;
+
 @SpringBootApplication
+@EnableAsync
 public class CoursesApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
+++ b/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
@@ -1,0 +1,45 @@
+package edu.ucsb.cs156.courses.collections;
+
+import java.util.List;
+
+import org.bson.types.ObjectId;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+import edu.ucsb.cs156.courses.documents.ConvertedSection;
+
+@Repository
+public interface ConvertedSectionCollection extends MongoRepository<ConvertedSection, ObjectId> {
+    /**
+     * Returns a {@link ConvertedSection} identified by that quarter it is offered and its 13 character course id.
+     * <br>
+     * Note: the courseId must be a properly padded 13 character course id. If you have the course's subject code
+     * (e.g. CMPSC) and course number (e.g. 190J), use the overloaded version of this method instead.
+     * {@link #findByQuarterAndCourseId(String, String, String)}
+     *
+     * @param quarter  the quarter that the course is offered
+     * @param courseId the course's 13 character course id
+     * @return a List of {@link ConvertedSection}, if a matching course was found
+     * @see #findByQuarterAndCourseId(String, String, String)
+     */
+    List<ConvertedSection> findByQuarterAndCourseId(String quarter, String courseId);
+
+    /**
+     * Returns a {@link ConvertedSection} identified by the quarter that it is offered, its subject code, and its course
+     * number.
+     * <br>
+     * This is a convenience method that calls {@link #findByQuarterAndCourseId(String, String)} with a properly
+     * padded course id.
+     *
+     * @param quarter      the quarter that the course is offered
+     * @param subjectCode  the course's subject code
+     * @param courseNumber the course's course number
+     * @return a List of {@link ConvertedSection}, if a matching course was found
+     * @see #findByQuarterAndCourseId(String, String)
+     */
+    default List<ConvertedSection> findByQuarterAndCourseId(String quarter,
+                                                                 String subjectCode,
+                                                                 String courseNumber) {
+        return findByQuarterAndCourseId(quarter, String.format("%-8s%-5s", subjectCode, courseNumber));
+    }
+
+}

--- a/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
+++ b/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
@@ -1,45 +1,15 @@
 package edu.ucsb.cs156.courses.collections;
 
-import java.util.List;
+import java.util.Optional;
 
 import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 import org.springframework.stereotype.Repository;
 import edu.ucsb.cs156.courses.documents.ConvertedSection;
 
 @Repository
 public interface ConvertedSectionCollection extends MongoRepository<ConvertedSection, ObjectId> {
-    /**
-     * Returns a {@link ConvertedSection} identified by that quarter it is offered and its 13 character course id.
-     * <br>
-     * Note: the courseId must be a properly padded 13 character course id. If you have the course's subject code
-     * (e.g. CMPSC) and course number (e.g. 190J), use the overloaded version of this method instead.
-     * {@link #findByQuarterAndCourseId(String, String, String)}
-     *
-     * @param quarter  the quarter that the course is offered
-     * @param courseId the course's 13 character course id
-     * @return a List of {@link ConvertedSection}, if a matching course was found
-     * @see #findByQuarterAndCourseId(String, String, String)
-     */
-    List<ConvertedSection> findByQuarterAndCourseId(String quarter, String courseId);
-
-    /**
-     * Returns a {@link ConvertedSection} identified by the quarter that it is offered, its subject code, and its course
-     * number.
-     * <br>
-     * This is a convenience method that calls {@link #findByQuarterAndCourseId(String, String)} with a properly
-     * padded course id.
-     *
-     * @param quarter      the quarter that the course is offered
-     * @param subjectCode  the course's subject code
-     * @param courseNumber the course's course number
-     * @return a List of {@link ConvertedSection}, if a matching course was found
-     * @see #findByQuarterAndCourseId(String, String)
-     */
-    default List<ConvertedSection> findByQuarterAndCourseId(String quarter,
-                                                                 String subjectCode,
-                                                                 String courseNumber) {
-        return findByQuarterAndCourseId(quarter, String.format("%-8s%-5s", subjectCode, courseNumber));
-    }
-
+    @Query("{'courseInfo.quarter': ?0, 'section.enrollCode': ?1}")
+    Optional<ConvertedSection> findOneByQuarterAndEnrollCode(String quarter, String enrollCode);
 }

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
@@ -1,0 +1,65 @@
+package edu.ucsb.cs156.courses.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import edu.ucsb.cs156.courses.entities.Job;
+import edu.ucsb.cs156.courses.repositories.JobsRepository;
+import edu.ucsb.cs156.courses.services.jobs.JobService;
+
+@Slf4j
+@Api(description = "Jobs")
+@RequestMapping("/api/jobs")
+@RestController
+public class JobsController extends ApiController {
+    @Autowired
+    private JobsRepository jobsRepository;
+
+    @Autowired
+    private JobService jobService;
+
+    @Autowired
+    ObjectMapper mapper;
+
+    @ApiOperation(value = "List all jobs")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/all")
+    public Iterable<Job> allJobs() {
+        Iterable<Job> jobs = jobsRepository.findAll();
+        return jobs;
+    }
+
+    @ApiOperation(value = "Launch Test Job (click fail if you want to test exception handling)")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/launch/testjob")
+    public Job launchTestJob(
+        @ApiParam("fail") @RequestParam Boolean fail, 
+        @ApiParam("sleepMs") @RequestParam Integer sleepMs
+    ) {
+
+        return jobService.runAsJob(ctx -> {
+            ctx.log("Hello World! from test job!");
+            Thread.sleep(sleepMs);
+            if (fail) {
+                throw new Exception("Fail!");
+            }
+            ctx.log("Goodbye from test job!");
+          });
+    }
+
+}

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import edu.ucsb.cs156.courses.entities.Job;
 import edu.ucsb.cs156.courses.jobs.UpdateCourseDataJob;
+import edu.ucsb.cs156.courses.jobs.UpdateCourseDataJobFactory;
 import edu.ucsb.cs156.courses.jobs.TestJob;
 import edu.ucsb.cs156.courses.repositories.JobsRepository;
 import edu.ucsb.cs156.courses.services.jobs.JobService;
@@ -36,6 +37,9 @@ public class JobsController extends ApiController {
 
     @Autowired
     ObjectMapper mapper;
+
+    @Autowired
+    UpdateCourseDataJobFactory updateCourseDataJobFactory;
 
     @ApiOperation(value = "List all jobs")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
@@ -67,10 +71,10 @@ public class JobsController extends ApiController {
         @ApiParam("quarter (YYYYQ format)") @RequestParam String quarterYYYYQ,
         @ApiParam("subject area") @RequestParam String subjectArea
     ) {
-        UpdateCourseDataJob updateCourseDataJob = UpdateCourseDataJob.builder()
-        .quarterYYYYQ(quarterYYYYQ)
-        .subjectArea(subjectArea)
-        .build();
+       
+        UpdateCourseDataJob updateCourseDataJob = updateCourseDataJobFactory.create(
+            subjectArea,
+            quarterYYYYQ);
 
         return jobService.runAsJob(updateCourseDataJob);
     }

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
@@ -7,7 +7,7 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 
 import org.springframework.beans.factory.annotation.Autowired;
-
+import org.springframework.context.annotation.Import;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
 import edu.ucsb.cs156.courses.entities.Job;
 import edu.ucsb.cs156.courses.jobs.UpdateCourseDataJob;
 import edu.ucsb.cs156.courses.jobs.UpdateCourseDataJobFactory;
@@ -31,6 +32,9 @@ import edu.ucsb.cs156.courses.services.jobs.JobService;
 public class JobsController extends ApiController {
     @Autowired
     private JobsRepository jobsRepository;
+
+    @Autowired
+    private ConvertedSectionCollection convertedSectionCollection;
 
     @Autowired
     private JobService jobService;

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
-import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -19,10 +18,12 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import edu.ucsb.cs156.courses.entities.Job;
+import edu.ucsb.cs156.courses.jobs.UpdateCourseDataJob;
+import edu.ucsb.cs156.courses.jobs.TestJob;
 import edu.ucsb.cs156.courses.repositories.JobsRepository;
 import edu.ucsb.cs156.courses.services.jobs.JobService;
 
-@Slf4j
+
 @Api(description = "Jobs")
 @RequestMapping("/api/jobs")
 @RestController
@@ -52,14 +53,26 @@ public class JobsController extends ApiController {
         @ApiParam("sleepMs") @RequestParam Integer sleepMs
     ) {
 
-        return jobService.runAsJob(ctx -> {
-            ctx.log("Hello World! from test job!");
-            Thread.sleep(sleepMs);
-            if (fail) {
-                throw new Exception("Fail!");
-            }
-            ctx.log("Goodbye from test job!");
-          });
+        TestJob testJob = TestJob.builder()
+        .fail(fail)
+        .sleepMs(sleepMs)
+        .build();
+        return jobService.runAsJob(testJob);
+    }
+    
+    @ApiOperation(value = "Launch Job to Update Course Data")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/launch/updateCourses")
+    public Job launchUpdateCourseDataJob(
+        @ApiParam("quarter (YYYYQ format)") @RequestParam String quarterYYYYQ,
+        @ApiParam("subject area") @RequestParam String subjectArea
+    ) {
+        UpdateCourseDataJob updateCourseDataJob = UpdateCourseDataJob.builder()
+        .quarterYYYYQ(quarterYYYYQ)
+        .subjectArea(subjectArea)
+        .build();
+
+        return jobService.runAsJob(updateCourseDataJob);
     }
 
 }

--- a/src/main/java/edu/ucsb/cs156/courses/documents/ConvertedSection.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/ConvertedSection.java
@@ -1,5 +1,7 @@
 package edu.ucsb.cs156.courses.documents;
 
+import org.springframework.data.mongodb.core.mapping.Document;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -9,6 +11,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Document(collection = "courses")
 public class ConvertedSection {
     private CourseInfo courseInfo;
     private Section section;

--- a/src/main/java/edu/ucsb/cs156/courses/documents/ConvertedSection.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/ConvertedSection.java
@@ -17,4 +17,20 @@ public class ConvertedSection {
     private ObjectId _id;
     private CourseInfo courseInfo;
     private Section section;
+
+    @Override
+    public Object clone() throws CloneNotSupportedException {
+
+        ConvertedSection newConvertedSection = new ConvertedSection();
+        
+        newConvertedSection.set_id(this._id);
+
+        CourseInfo newCourseInfo = (CourseInfo) this.getCourseInfo().clone();
+        newConvertedSection.setCourseInfo(newCourseInfo);
+
+        Section newSection = (Section) this.getSection().clone();
+        newConvertedSection.setSection(newSection);
+
+        return newConvertedSection;
+    }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/documents/ConvertedSection.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/ConvertedSection.java
@@ -1,5 +1,6 @@
 package edu.ucsb.cs156.courses.documents;
 
+import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import lombok.AllArgsConstructor;
@@ -13,6 +14,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Document(collection = "courses")
 public class ConvertedSection {
+    private ObjectId _id;
     private CourseInfo courseInfo;
     private Section section;
 }

--- a/src/main/java/edu/ucsb/cs156/courses/documents/CourseInfo.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/CourseInfo.java
@@ -14,9 +14,14 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class CourseInfo {
+public class CourseInfo implements Cloneable {
     private String quarter;
     private String courseId;
     private String title;
     private String description;
+
+    public Object clone() throws CloneNotSupportedException {
+        CourseInfo newCourseInfo = (CourseInfo) super.clone();
+        return newCourseInfo;
+    }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/documents/CoursePage.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/CoursePage.java
@@ -14,9 +14,7 @@ import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Data
-@Builder
 @NoArgsConstructor
-@AllArgsConstructor
 @Slf4j
 public class CoursePage {
     private int pageNumber;

--- a/src/main/java/edu/ucsb/cs156/courses/documents/Instructor.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/Instructor.java
@@ -5,12 +5,15 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-
 @Data
-@Builder
-@NoArgsConstructor
 @AllArgsConstructor
-public class Instructor {
+@NoArgsConstructor
+@Builder
+public class Instructor implements Cloneable {
     private String instructor;
     private String functionCode;
+    @Override
+    public Object clone() throws CloneNotSupportedException {
+        return super.clone();
+    }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/documents/Section.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/Section.java
@@ -73,4 +73,28 @@ public class Section {
      * List of {@link Instructor} objects for this course
      */
     private List<Instructor> instructors;
+
+    public Section clone() {
+        Section newSection = new Section();
+        newSection.setEnrollCode(this.getEnrollCode());
+        newSection.setSection(this.getSection());
+        newSection.setSession(this.getSession());
+        newSection.setClassClosed(this.getClassClosed());
+        newSection.setCourseCancelled(this.getCourseCancelled());
+        newSection.setGradingOptionCode(this.getGradingOptionCode());
+        newSection.setEnrolledTotal(this.getEnrolledTotal());
+        newSection.setMaxEnroll(this.getMaxEnroll());
+        newSection.setSecondaryStatus(this.getSecondaryStatus());
+        newSection.setDepartmentApprovalRequired(this.isDepartmentApprovalRequired());
+        newSection.setInstructorApprovalRequired(this.isInstructorApprovalRequired());
+        newSection.setRestrictionLevel(this.getRestrictionLevel());
+        newSection.setRestrictionMajor(this.getRestrictionMajor());
+        newSection.setRestrictionMajorPass(this.getRestrictionMajorPass());
+        newSection.setRestrictionMinor(this.getRestrictionMinor());
+        newSection.setRestrictionMinorPass(this.getRestrictionMinorPass());
+        newSection.setConcurrentCourses(this.getConcurrentCourses());
+        newSection.setTimeLocations(this.getTimeLocations());
+        newSection.setInstructors(this.getInstructors());
+        return newSection;
+    }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/documents/Section.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/Section.java
@@ -1,17 +1,15 @@
 package edu.ucsb.cs156.courses.documents;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Collections;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
-@Builder
 @NoArgsConstructor
-@AllArgsConstructor
-public class Section {
+public class Section implements Cloneable {
 
     /** a unique number assigned to a section */
     private String enrollCode;
@@ -74,27 +72,25 @@ public class Section {
      */
     private List<Instructor> instructors;
 
-    public Section clone() {
-        Section newSection = new Section();
-        newSection.setEnrollCode(this.getEnrollCode());
-        newSection.setSection(this.getSection());
-        newSection.setSession(this.getSession());
-        newSection.setClassClosed(this.getClassClosed());
-        newSection.setCourseCancelled(this.getCourseCancelled());
-        newSection.setGradingOptionCode(this.getGradingOptionCode());
-        newSection.setEnrolledTotal(this.getEnrolledTotal());
-        newSection.setMaxEnroll(this.getMaxEnroll());
-        newSection.setSecondaryStatus(this.getSecondaryStatus());
-        newSection.setDepartmentApprovalRequired(this.isDepartmentApprovalRequired());
-        newSection.setInstructorApprovalRequired(this.isInstructorApprovalRequired());
-        newSection.setRestrictionLevel(this.getRestrictionLevel());
-        newSection.setRestrictionMajor(this.getRestrictionMajor());
-        newSection.setRestrictionMajorPass(this.getRestrictionMajorPass());
-        newSection.setRestrictionMinor(this.getRestrictionMinor());
-        newSection.setRestrictionMinorPass(this.getRestrictionMinorPass());
-        newSection.setConcurrentCourses(this.getConcurrentCourses());
-        newSection.setTimeLocations(this.getTimeLocations());
-        newSection.setInstructors(this.getInstructors());
+    public Object clone() throws CloneNotSupportedException {
+
+        Section newSection = (Section) super.clone();
+        // List<String> copyConcurrentCourses = new ArrayList<>();
+        // Collections.copy(copyConcurrentCourses, this.getConcurrentCourses());
+        // newSection.setConcurrentCourses(copyConcurrentCourses);
+
+        // List<TimeLocation> copyTimeLocations = new ArrayList<>();
+        // for (TimeLocation tl : this.getTimeLocations()) {
+        //     copyTimeLocations.add((TimeLocation) tl.clone());
+        // }
+        // newSection.setTimeLocations(copyTimeLocations);
+
+        // List<Instructor> copyInstructors = new ArrayList<>();
+        // for (Instructor i : this.getInstructors()) {
+        //     copyInstructors.add((Instructor) i.clone());
+        // }
+        // newSection.setInstructors(copyInstructors);
+
         return newSection;
     }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/documents/TimeLocation.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/TimeLocation.java
@@ -7,13 +7,18 @@ import lombok.NoArgsConstructor;
 
 @Data
 @Builder
-@NoArgsConstructor
 @AllArgsConstructor
-public class TimeLocation {
+@NoArgsConstructor
+public class TimeLocation implements Cloneable {
     private String room;
     private String building;
     private String roomCapacity;
     private String days; 
     private String beginTime; 
     private String endTime;
+
+    @Override
+    public Object clone() throws CloneNotSupportedException {
+        return super.clone();
+    }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/entities/Job.java
+++ b/src/main/java/edu/ucsb/cs156/courses/entities/Job.java
@@ -9,7 +9,7 @@ import javax.persistence.*;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 
 @Data
 @AllArgsConstructor
@@ -29,9 +29,9 @@ public class Job {
     private User createdBy;
 
     @CreatedDate
-    private LocalDateTime createdAt;
+    private ZonedDateTime createdAt;
     @LastModifiedDate
-    private LocalDateTime updatedAt;
+    private ZonedDateTime updatedAt;
 
     private String status;
     private String log;

--- a/src/main/java/edu/ucsb/cs156/courses/entities/Job.java
+++ b/src/main/java/edu/ucsb/cs156/courses/entities/Job.java
@@ -1,0 +1,38 @@
+package edu.ucsb.cs156.courses.entities;
+
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Entity(name = "jobs")
+@EntityListeners(AuditingEntityListener.class)
+
+public class Job {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @JsonIgnore
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "created_by_id")
+    private User createdBy;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    private String status;
+    private String log;
+}

--- a/src/main/java/edu/ucsb/cs156/courses/entities/Job.java
+++ b/src/main/java/edu/ucsb/cs156/courses/entities/Job.java
@@ -34,5 +34,7 @@ public class Job {
     private ZonedDateTime updatedAt;
 
     private String status;
+
+    @Column(columnDefinition="TEXT") // needed for long strings, i.e. log entries longer than 255 characters
     private String log;
 }

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/TestJob.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/TestJob.java
@@ -1,0 +1,33 @@
+package edu.ucsb.cs156.courses.jobs;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import edu.ucsb.cs156.courses.services.jobs.JobContext;
+import edu.ucsb.cs156.courses.services.jobs.JobContextConsumer;
+import lombok.Builder;
+
+@Builder
+public class TestJob implements JobContextConsumer {
+
+    private boolean fail;
+    private int sleepMs;
+
+    @Override
+    public void accept(JobContext ctx) throws Exception {
+            // Ensure this is not null 
+            Authentication authentication =  SecurityContextHolder.getContext().getAuthentication();
+
+            ctx.log("Hello World! from test job!");
+            if (authentication == null) {
+                ctx.log("authentication is null");
+            } else {
+                ctx.log("authentication is not null");
+            }
+            Thread.sleep(sleepMs);
+            if (fail) {
+                throw new Exception("Fail!");
+            }
+            ctx.log("Goodbye from test job!");
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJob.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJob.java
@@ -1,21 +1,7 @@
 package edu.ucsb.cs156.courses.jobs;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
-
-import com.mongodb.WriteError;
-import com.mongodb.client.model.Filters;
-import com.mongodb.client.result.UpdateResult;
-
-import org.springframework.context.annotation.AnnotationConfigApplicationContext;
-import org.springframework.data.mongodb.core.query.Update;
-import org.springframework.data.mongodb.core.query.Criteria;
-import org.springframework.data.mongodb.core.query.Query;
-
 
 
 import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
@@ -25,9 +11,11 @@ import edu.ucsb.cs156.courses.services.jobs.JobContext;
 import edu.ucsb.cs156.courses.services.jobs.JobContextConsumer;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 
 
 @AllArgsConstructor
+@Slf4j
 public class UpdateCourseDataJob implements JobContextConsumer {
 
     @Getter private String subjectArea;
@@ -51,8 +39,10 @@ public class UpdateCourseDataJob implements JobContextConsumer {
 
         for (ConvertedSection section : convertedSections) {
             try {
+                String quarter = section.getCourseInfo().getQuarter();
+                String enrollCode =  section.getSection().getEnrollCode();
                 Optional<ConvertedSection> optionalSection = convertedSectionCollection
-                        .findOneByQuarterAndEnrollCode(section.getCourseInfo().getQuarter(), section.getSection().getEnrollCode());
+                        .findOneByQuarterAndEnrollCode(quarter,enrollCode);
                 if (optionalSection.isPresent()) {
                     ConvertedSection existingSection = optionalSection.get();
                     existingSection.setCourseInfo(section.getCourseInfo());

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJob.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJob.java
@@ -1,0 +1,21 @@
+package edu.ucsb.cs156.courses.jobs;
+
+
+import edu.ucsb.cs156.courses.services.jobs.JobContext;
+import edu.ucsb.cs156.courses.services.jobs.JobContextConsumer;
+import lombok.Builder;
+
+@Builder
+public class UpdateCourseDataJob implements JobContextConsumer {
+
+    private String subjectArea;
+    private String quarterYYYYQ; 
+
+    @Override
+    public void accept(JobContext ctx) throws Exception {
+        ctx.log("Updating courses for [" + subjectArea + " " + quarterYYYYQ + "]");
+        ctx.log("This is where the code to pull data from the UCSB API would go");
+        ctx.log("This is where the code to store that data in MongoDB would go");
+        ctx.log("Courses for [" + subjectArea + " " + quarterYYYYQ + "] have been updated");
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJob.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJob.java
@@ -1,20 +1,35 @@
 package edu.ucsb.cs156.courses.jobs;
 
+import java.util.List;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+
+import edu.ucsb.cs156.courses.documents.ConvertedSection;
+import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
 import edu.ucsb.cs156.courses.services.jobs.JobContext;
 import edu.ucsb.cs156.courses.services.jobs.JobContextConsumer;
-import lombok.Builder;
+import lombok.AllArgsConstructor;
+import lombok.Data;
 
-@Builder
+@Data
+@AllArgsConstructor
 public class UpdateCourseDataJob implements JobContextConsumer {
 
     private String subjectArea;
     private String quarterYYYYQ; 
+    private UCSBCurriculumService ucsbCurriculumService;
 
     @Override
     public void accept(JobContext ctx) throws Exception {
         ctx.log("Updating courses for [" + subjectArea + " " + quarterYYYYQ + "]");
-        ctx.log("This is where the code to pull data from the UCSB API would go");
+       
+        List<ConvertedSection> convertedSections = ucsbCurriculumService.getConvertedSections(subjectArea,  quarterYYYYQ, "A");
+        ctx.log("Found " + convertedSections.size() + " sections");
+        
         ctx.log("This is where the code to store that data in MongoDB would go");
         ctx.log("Courses for [" + subjectArea + " " + quarterYYYYQ + "] have been updated");
     }

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJob.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJob.java
@@ -24,16 +24,16 @@ import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
 import edu.ucsb.cs156.courses.services.jobs.JobContext;
 import edu.ucsb.cs156.courses.services.jobs.JobContextConsumer;
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Getter;
 
-@Data
+
 @AllArgsConstructor
 public class UpdateCourseDataJob implements JobContextConsumer {
 
-    private String subjectArea;
-    private String quarterYYYYQ;
-    private UCSBCurriculumService ucsbCurriculumService;
-    private ConvertedSectionCollection convertedSectionCollection;
+    @Getter private String subjectArea;
+    @Getter private String quarterYYYYQ;
+    @Getter private UCSBCurriculumService ucsbCurriculumService;
+    @Getter private ConvertedSectionCollection convertedSectionCollection;
 
     @Override
     public void accept(JobContext ctx) throws Exception {

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJob.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJob.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component;
 
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
-
+import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
 import edu.ucsb.cs156.courses.documents.ConvertedSection;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
 import edu.ucsb.cs156.courses.services.jobs.JobContext;
@@ -22,15 +22,21 @@ public class UpdateCourseDataJob implements JobContextConsumer {
     private String subjectArea;
     private String quarterYYYYQ; 
     private UCSBCurriculumService ucsbCurriculumService;
+    private ConvertedSectionCollection convertedSectionCollection;
 
     @Override
     public void accept(JobContext ctx) throws Exception {
         ctx.log("Updating courses for [" + subjectArea + " " + quarterYYYYQ + "]");
        
         List<ConvertedSection> convertedSections = ucsbCurriculumService.getConvertedSections(subjectArea,  quarterYYYYQ, "A");
+
         ctx.log("Found " + convertedSections.size() + " sections");
-        
-        ctx.log("This is where the code to store that data in MongoDB would go");
+        ctx.log("Storing in MongoDB Collection...");
+
+        List<ConvertedSection> saved = convertedSectionCollection.saveAll(convertedSections);
+
+        ctx.log(saved.size() + " sections saved in MongoDB Collection...");
+
         ctx.log("Courses for [" + subjectArea + " " + quarterYYYYQ + "] have been updated");
     }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobFactory.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobFactory.java
@@ -1,0 +1,21 @@
+package edu.ucsb.cs156.courses.jobs;
+
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
+import lombok.extern.slf4j.Slf4j;
+
+
+@Service
+@Slf4j
+public class UpdateCourseDataJobFactory  {
+
+    @Autowired
+    private UCSBCurriculumService ucsbCurriculumService;
+
+    public UpdateCourseDataJob create(String subjectArea, String quarterYYYYQ) {
+        log.info("ucsbCurriculumService = " + ucsbCurriculumService);
+        return new UpdateCourseDataJob(subjectArea, quarterYYYYQ, ucsbCurriculumService);
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobFactory.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobFactory.java
@@ -1,11 +1,11 @@
 package edu.ucsb.cs156.courses.jobs;
 
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
 import lombok.extern.slf4j.Slf4j;
-
 
 @Service
 @Slf4j
@@ -14,8 +14,12 @@ public class UpdateCourseDataJobFactory  {
     @Autowired
     private UCSBCurriculumService ucsbCurriculumService;
 
+    @Autowired
+    private ConvertedSectionCollection convertedSectionCollection;
+
     public UpdateCourseDataJob create(String subjectArea, String quarterYYYYQ) {
         log.info("ucsbCurriculumService = " + ucsbCurriculumService);
-        return new UpdateCourseDataJob(subjectArea, quarterYYYYQ, ucsbCurriculumService);
+        log.info("convertedSectionCollection = " + convertedSectionCollection);
+        return new UpdateCourseDataJob(subjectArea, quarterYYYYQ, ucsbCurriculumService, convertedSectionCollection);
     }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/repositories/JobsRepository.java
+++ b/src/main/java/edu/ucsb/cs156/courses/repositories/JobsRepository.java
@@ -1,0 +1,11 @@
+package edu.ucsb.cs156.courses.repositories;
+
+import edu.ucsb.cs156.courses.entities.Job;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface JobsRepository extends CrudRepository<Job, Long> {
+
+}

--- a/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
@@ -27,6 +27,8 @@ import edu.ucsb.cs156.courses.documents.Course;
 import edu.ucsb.cs156.courses.documents.CourseInfo;
 import edu.ucsb.cs156.courses.documents.CoursePage;
 import edu.ucsb.cs156.courses.documents.Section;
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.web.util.UriComponentsBuilder;
 import java.util.Map;
 import java.util.HashMap;
@@ -36,13 +38,12 @@ import java.io.*;
 /**
  * Service object that wraps the UCSB Academic Curriculum API
  */
-@Service("ucs")
+@Service
+@Slf4j
 public class UCSBCurriculumService {
 
     @Autowired
     private ObjectMapper objectMapper;
-
-    private Logger logger = LoggerFactory.getLogger(UCSBCurriculumService.class);
 
     @Value("${app.ucsb.api.consumer_key}")
     private String apiKey;
@@ -81,7 +82,7 @@ public class UCSBCurriculumService {
             url = CURRICULUM_ENDPOINT + params;
         }
 
-        logger.info("url=" + url);
+        log.info("url=" + url);
 
         String retVal = "";
         MediaType contentType = null;
@@ -94,7 +95,7 @@ public class UCSBCurriculumService {
         } catch (HttpClientErrorException e) {
             retVal = "{\"error\": \"401: Unauthorized\"}";
         }
-        logger.info("json: {} contentType: {} statusCode: {}", retVal, contentType, statusCode);
+        log.info("json: {} contentType: {} statusCode: {}", retVal, contentType, statusCode);
         return retVal;
     }
 
@@ -125,7 +126,7 @@ public class UCSBCurriculumService {
 
         HttpEntity<String> entity = new HttpEntity<>("body", headers);
 
-        logger.info("url=" + SUBJECTS_ENDPOINT);
+        log.info("url=" + SUBJECTS_ENDPOINT);
 
         String retVal = "";
         MediaType contentType = null;
@@ -138,7 +139,7 @@ public class UCSBCurriculumService {
         } catch (HttpClientErrorException e) {
             retVal = "{\"error\": \"401: Unauthorized\"}";
         }
-        logger.info("json: {} contentType: {} statusCode: {}", retVal, contentType, statusCode);
+        log.info("json: {} contentType: {} statusCode: {}", retVal, contentType, statusCode);
         return retVal;
     }
 
@@ -155,7 +156,7 @@ public class UCSBCurriculumService {
         String url = SECTION_ENDPOINT;
 
 
-        logger.info("url=" + url);
+        log.info("url=" + url);
 
         String urlTemplate = UriComponentsBuilder.fromHttpUrl(url)
         .queryParam("quarter", "{quarter}")
@@ -183,7 +184,7 @@ public class UCSBCurriculumService {
             retVal = "{\"error\": \"Enroll code doesn't exist in that quarter.\"}";
         }
 
-        logger.info("json: {} contentType: {} statusCode: {}", retVal, contentType, statusCode);
+        log.info("json: {} contentType: {} statusCode: {}", retVal, contentType, statusCode);
         return retVal;
     }
      
@@ -201,7 +202,7 @@ public class UCSBCurriculumService {
 
         String url = "https://api.ucsb.edu/academics/curriculums/v3/classsection/" + quarter + "/" + enrollCd;
 
-        logger.info("url=" + url);
+        log.info("url=" + url);
 
         String retVal = "";
         MediaType contentType = null;
@@ -214,7 +215,7 @@ public class UCSBCurriculumService {
         } catch (HttpClientErrorException e) {
             retVal = "{\"error\": \"401: Unauthorized\"}";
         }
-        logger.info("json: {} contentType: {} statusCode: {}", retVal, contentType, statusCode);
+        log.info("json: {} contentType: {} statusCode: {}", retVal, contentType, statusCode);
         return retVal;
 
     }

--- a/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
@@ -36,7 +36,7 @@ import java.io.*;
 /**
  * Service object that wraps the UCSB Academic Curriculum API
  */
-@Service
+@Service("ucs")
 public class UCSBCurriculumService {
 
     @Autowired

--- a/src/main/java/edu/ucsb/cs156/courses/services/jobs/JobContext.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/jobs/JobContext.java
@@ -15,6 +15,7 @@ public class JobContext {
     log.info("Job %s: %s".formatted(job.getId(), message));
     String previousLog = job.getLog() == null ? "" : (job.getLog() + "\n");
     job.setLog(previousLog + message);
-    jobsRepository.save(job);
+    if (jobsRepository!=null)
+      jobsRepository.save(job);
   }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/services/jobs/JobContext.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/jobs/JobContext.java
@@ -1,0 +1,20 @@
+package edu.ucsb.cs156.courses.services.jobs;
+
+import edu.ucsb.cs156.courses.entities.Job;
+import edu.ucsb.cs156.courses.repositories.JobsRepository;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@AllArgsConstructor
+@Slf4j
+public class JobContext {
+  private JobsRepository jobsRepository;
+  private Job job;
+
+  public void log(String message) {
+    log.info("Job %s: %s".formatted(job.getId(), message));
+    String previousLog = job.getLog() == null ? "" : (job.getLog() + "\n");
+    job.setLog(previousLog + message);
+    jobsRepository.save(job);
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/courses/services/jobs/JobContextConsumer.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/jobs/JobContextConsumer.java
@@ -1,0 +1,6 @@
+package edu.ucsb.cs156.courses.services.jobs;
+
+@FunctionalInterface
+public interface JobContextConsumer {
+  void accept(JobContext c) throws Exception;
+}

--- a/src/main/java/edu/ucsb/cs156/courses/services/jobs/JobService.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/jobs/JobService.java
@@ -19,8 +19,6 @@ public class JobService {
   @Lazy
   @Autowired
   private JobService self;
-
-
   public Job runAsJob(JobContextConsumer jobFunction) {
     Job job = Job.builder()
       .createdBy(currentUserService.getUser())

--- a/src/main/java/edu/ucsb/cs156/courses/services/jobs/JobService.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/jobs/JobService.java
@@ -1,0 +1,58 @@
+package edu.ucsb.cs156.courses.services.jobs;
+
+import edu.ucsb.cs156.courses.entities.Job;
+import edu.ucsb.cs156.courses.repositories.JobsRepository;
+import edu.ucsb.cs156.courses.services.CurrentUserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class JobService {
+  @Autowired
+  private JobsRepository jobsRepository;
+
+  @Autowired
+  private CurrentUserService currentUserService;
+
+  @Lazy
+  @Autowired
+  private JobService self;
+
+
+  public Job runAsJob(JobContextConsumer jobFunction) {
+    Job job = Job.builder()
+      .createdBy(currentUserService.getUser())
+      .status("running")
+      .build();
+
+    jobsRepository.save(job);
+    self.runJobAsync(job, jobFunction, SecurityContextHolder.getContext());
+
+    return job;
+  }
+
+  
+
+  @Async
+  public void runJobAsync(Job job, JobContextConsumer jobFunction, SecurityContext securityContext) {
+    JobContext context = new JobContext(jobsRepository, job);
+
+    SecurityContextHolder.setContext(securityContext);
+
+    try {
+      jobFunction.accept(context);
+    } catch (Exception e) {
+      e.printStackTrace();
+      job.setStatus("error");
+      context.log(e.getMessage());
+      return;
+    }
+
+    job.setStatus("complete");
+    jobsRepository.save(job);
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/courses/services/jobs/JobService.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/jobs/JobService.java
@@ -40,7 +40,6 @@ public class JobService {
     try {
       jobFunction.accept(context);
     } catch (Exception e) {
-      e.printStackTrace();
       job.setStatus("error");
       context.log(e.getMessage());
       return;

--- a/src/main/java/edu/ucsb/cs156/courses/services/jobs/JobService.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/jobs/JobService.java
@@ -6,8 +6,6 @@ import edu.ucsb.cs156.courses.services.CurrentUserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.scheduling.annotation.Async;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -30,7 +28,7 @@ public class JobService {
       .build();
 
     jobsRepository.save(job);
-    self.runJobAsync(job, jobFunction, SecurityContextHolder.getContext());
+    self.runJobAsync(job, jobFunction);
 
     return job;
   }
@@ -38,10 +36,8 @@ public class JobService {
   
 
   @Async
-  public void runJobAsync(Job job, JobContextConsumer jobFunction, SecurityContext securityContext) {
+  public void runJobAsync(Job job, JobContextConsumer jobFunction) {
     JobContext context = new JobContext(jobsRepository, job);
-
-    SecurityContextHolder.setContext(securityContext);
 
     try {
       jobFunction.accept(context);

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/ApiControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/ApiControllerTests.java
@@ -6,6 +6,7 @@ import edu.ucsb.cs156.courses.repositories.UserRepository;
 import edu.ucsb.cs156.courses.testconfig.TestConfig;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
@@ -24,6 +25,7 @@ import java.util.Arrays;
 
 @WebMvcTest(controllers = UsersController.class)
 @Import(TestConfig.class)
+@AutoConfigureDataJpa
 public class ApiControllerTests extends ControllerTestCase {
 
   @MockBean

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/CSRFControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/CSRFControllerTests.java
@@ -5,6 +5,7 @@ import edu.ucsb.cs156.courses.repositories.UserRepository;
 import edu.ucsb.cs156.courses.testconfig.TestConfig;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
@@ -18,6 +19,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ActiveProfiles("development")
 @WebMvcTest(controllers = CSRFController.class)
 @Import(TestConfig.class)
+@AutoConfigureDataJpa
 public class CSRFControllerTests extends ControllerTestCase {
 
   @MockBean

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/JobsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/JobsControllerTests.java
@@ -34,9 +34,11 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 
 import edu.ucsb.cs156.courses.ControllerTestCase;
 import edu.ucsb.cs156.courses.entities.User;
+import edu.ucsb.cs156.courses.jobs.UpdateCourseDataJobFactory;
 import edu.ucsb.cs156.courses.entities.Job;
 import edu.ucsb.cs156.courses.repositories.UserRepository;
 import edu.ucsb.cs156.courses.repositories.JobsRepository;
+import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
 import edu.ucsb.cs156.courses.services.jobs.JobService;
 import lombok.extern.slf4j.Slf4j;
 
@@ -57,6 +59,12 @@ public class JobsControllerTests extends ControllerTestCase {
 
     @Autowired
     ObjectMapper objectMapper;
+
+    @MockBean
+    UCSBCurriculumService ucsbCurriculumService;
+
+    @MockBean
+    UpdateCourseDataJobFactory updateCourseDataJobFactory;
 
     @WithMockUser(roles = { "ADMIN" })
     @Test

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/JobsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/JobsControllerTests.java
@@ -1,0 +1,173 @@
+package edu.ucsb.cs156.courses.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+
+import static org.awaitility.Awaitility.await;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import edu.ucsb.cs156.courses.ControllerTestCase;
+import edu.ucsb.cs156.courses.entities.User;
+import edu.ucsb.cs156.courses.entities.Job;
+import edu.ucsb.cs156.courses.repositories.UserRepository;
+import edu.ucsb.cs156.courses.repositories.JobsRepository;
+import edu.ucsb.cs156.courses.services.jobs.JobService;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@WebMvcTest(controllers = JobsController.class)
+@Import(JobService.class)
+@AutoConfigureDataJpa
+public class JobsControllerTests extends ControllerTestCase {
+
+  @MockBean
+  JobsRepository jobsRepository;
+
+  @MockBean
+  UserRepository userRepository;
+
+  @Autowired
+  JobService jobService;
+
+  @Autowired
+  ObjectMapper objectMapper;
+
+  @WithMockUser(roles = { "ADMIN" })
+  @Test
+  public void admin_can_get_all_jobs() throws Exception {
+
+    // arrange
+
+    Job job1 = Job.builder().log("this is job 1").build();
+    Job job2 = Job.builder().log("this is job 2").build();
+
+    ArrayList<Job> expectedJobs = new ArrayList<>();
+    expectedJobs.addAll(Arrays.asList(job1, job2));
+
+    when(jobsRepository.findAll()).thenReturn(expectedJobs);
+
+    // act
+    MvcResult response = mockMvc.perform(get("/api/jobs/all"))
+        .andExpect(status().isOk()).andReturn();
+
+    // // assert
+
+    verify(jobsRepository, times(1)).findAll();
+    String expectedJson = mapper.writeValueAsString(expectedJobs);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = { "ADMIN" })
+  @Test
+  public void admin_can_launch_test_job() throws Exception {
+
+    // arrange
+
+    User user = currentUserService.getUser();
+
+    Job jobStarted = Job.builder()
+        .id(0L)
+        .createdBy(user)
+        .createdAt(null)
+        .updatedAt(null)
+        .status("running")
+        .log("Hello World! from test job!")
+        .build();
+
+    Job jobCompleted = Job.builder()
+        .id(0L)
+        .createdBy(user)
+        .createdAt(null)
+        .updatedAt(null)
+        .status("complete")
+        .log("Hello World! from test job!\nGoodbye from test job!")
+        .build();
+
+    when(jobsRepository.save(any(Job.class))).thenReturn(jobStarted).thenReturn(jobCompleted);
+
+    // act
+    MvcResult response = mockMvc.perform(post("/api/jobs/launch/testjob?fail=false&sleepMs=4000").with(csrf()))
+        .andExpect(status().isOk()).andReturn();
+
+    // assert
+    String responseString = response.getResponse().getContentAsString();
+    Job jobReturned = objectMapper.readValue(responseString, Job.class);
+
+    assertEquals("running", jobReturned.getStatus());
+
+    await().atMost(1, SECONDS)
+        .untilAsserted(() -> verify(jobsRepository, times(2)).save(eq(jobStarted)));
+    await().atMost(10, SECONDS)
+        .untilAsserted(() -> verify(jobsRepository, times(4)).save(eq(jobCompleted)));
+  }
+
+  @WithMockUser(roles = { "ADMIN" })
+  @Test
+  public void admin_can_launch_test_job_that_fails() throws Exception {
+
+    // arrange
+
+    User user = currentUserService.getUser();
+
+    Job jobStarted = Job.builder()
+        .id(0L)
+        .createdBy(user)
+        .createdAt(null)
+        .updatedAt(null)
+        .status("running")
+        .log("Hello World! from test job!")
+        .build();
+
+    Job jobFailed = Job.builder()
+        .id(0L)
+        .createdBy(user)
+        .createdAt(null)
+        .updatedAt(null)
+        .status("error")
+        .log("Hello World! from test job!\nFail!")
+        .build();
+
+    when(jobsRepository.save(any(Job.class))).thenReturn(jobStarted).thenReturn(jobFailed);
+
+    // act
+    MvcResult response = mockMvc.perform(post("/api/jobs/launch/testjob?fail=true&sleepMs=4000").with(csrf()))
+        .andExpect(status().isOk()).andReturn();
+
+    String responseString = response.getResponse().getContentAsString();
+    Job jobReturned = objectMapper.readValue(responseString, Job.class);
+
+    assertEquals("running", jobReturned.getStatus());
+
+    await().atMost(1, SECONDS)
+        .untilAsserted(() -> verify(jobsRepository, times(2)).save(eq(jobStarted)));
+
+    await().atMost(10, SECONDS)
+        .untilAsserted(() -> verify(jobsRepository, times(3)).save(eq(jobFailed)));
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/JobsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/JobsControllerTests.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs156.courses.controllers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -45,129 +46,145 @@ import lombok.extern.slf4j.Slf4j;
 @AutoConfigureDataJpa
 public class JobsControllerTests extends ControllerTestCase {
 
-  @MockBean
-  JobsRepository jobsRepository;
+    @MockBean
+    JobsRepository jobsRepository;
 
-  @MockBean
-  UserRepository userRepository;
+    @MockBean
+    UserRepository userRepository;
 
-  @Autowired
-  JobService jobService;
+    @Autowired
+    JobService jobService;
 
-  @Autowired
-  ObjectMapper objectMapper;
+    @Autowired
+    ObjectMapper objectMapper;
 
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void admin_can_get_all_jobs() throws Exception {
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void admin_can_get_all_jobs() throws Exception {
 
-    // arrange
+        // arrange
 
-    Job job1 = Job.builder().log("this is job 1").build();
-    Job job2 = Job.builder().log("this is job 2").build();
+        Job job1 = Job.builder().log("this is job 1").build();
+        Job job2 = Job.builder().log("this is job 2").build();
 
-    ArrayList<Job> expectedJobs = new ArrayList<>();
-    expectedJobs.addAll(Arrays.asList(job1, job2));
+        ArrayList<Job> expectedJobs = new ArrayList<>();
+        expectedJobs.addAll(Arrays.asList(job1, job2));
 
-    when(jobsRepository.findAll()).thenReturn(expectedJobs);
+        when(jobsRepository.findAll()).thenReturn(expectedJobs);
 
-    // act
-    MvcResult response = mockMvc.perform(get("/api/jobs/all"))
-        .andExpect(status().isOk()).andReturn();
+        // act
+        MvcResult response = mockMvc.perform(get("/api/jobs/all"))
+                .andExpect(status().isOk()).andReturn();
 
-    // // assert
+        // // assert
 
-    verify(jobsRepository, times(1)).findAll();
-    String expectedJson = mapper.writeValueAsString(expectedJobs);
-    String responseString = response.getResponse().getContentAsString();
-    assertEquals(expectedJson, responseString);
-  }
+        verify(jobsRepository, times(1)).findAll();
+        String expectedJson = mapper.writeValueAsString(expectedJobs);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
 
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void admin_can_launch_test_job() throws Exception {
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void admin_can_launch_test_job() throws Exception {
 
-    // arrange
+        // arrange
 
-    User user = currentUserService.getUser();
+        User user = currentUserService.getUser();
 
-    Job jobStarted = Job.builder()
-        .id(0L)
-        .createdBy(user)
-        .createdAt(null)
-        .updatedAt(null)
-        .status("running")
-        .log("Hello World! from test job!")
-        .build();
+        Job jobStarted = Job.builder()
+                .id(0L)
+                .createdBy(user)
+                .createdAt(null)
+                .updatedAt(null)
+                .status("running")
+                .log("Hello World! from test job!\nauthentication is not null")
+                .build();
 
-    Job jobCompleted = Job.builder()
-        .id(0L)
-        .createdBy(user)
-        .createdAt(null)
-        .updatedAt(null)
-        .status("complete")
-        .log("Hello World! from test job!\nGoodbye from test job!")
-        .build();
+        Job jobCompleted = Job.builder()
+                .id(0L)
+                .createdBy(user)
+                .createdAt(null)
+                .updatedAt(null)
+                .status("complete")
+                .log("Hello World! from test job!\nauthentication is not null\nGoodbye from test job!")
+                .build();
 
-    when(jobsRepository.save(any(Job.class))).thenReturn(jobStarted).thenReturn(jobCompleted);
+        when(jobsRepository.save(any(Job.class))).thenReturn(jobStarted).thenReturn(jobCompleted);
 
-    // act
-    MvcResult response = mockMvc.perform(post("/api/jobs/launch/testjob?fail=false&sleepMs=4000").with(csrf()))
-        .andExpect(status().isOk()).andReturn();
+        // act
+        MvcResult response = mockMvc.perform(post("/api/jobs/launch/testjob?fail=false&sleepMs=2000").with(csrf()))
+                .andExpect(status().isOk()).andReturn();
 
-    // assert
-    String responseString = response.getResponse().getContentAsString();
-    Job jobReturned = objectMapper.readValue(responseString, Job.class);
+        // assert
+        String responseString = response.getResponse().getContentAsString();
+        Job jobReturned = objectMapper.readValue(responseString, Job.class);
 
-    assertEquals("running", jobReturned.getStatus());
+        assertEquals("running", jobReturned.getStatus());
 
-    await().atMost(1, SECONDS)
-        .untilAsserted(() -> verify(jobsRepository, times(2)).save(eq(jobStarted)));
-    await().atMost(10, SECONDS)
-        .untilAsserted(() -> verify(jobsRepository, times(4)).save(eq(jobCompleted)));
-  }
+        await().atMost(1, SECONDS)
+                .untilAsserted(() -> verify(jobsRepository, times(3)).save(eq(jobStarted)));
+        await().atMost(10, SECONDS)
+                .untilAsserted(() -> verify(jobsRepository, times(5)).save(eq(jobCompleted)));
+    }
 
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void admin_can_launch_test_job_that_fails() throws Exception {
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void admin_can_launch_test_job_that_fails() throws Exception {
 
-    // arrange
+        // arrange
 
-    User user = currentUserService.getUser();
+        User user = currentUserService.getUser();
 
-    Job jobStarted = Job.builder()
-        .id(0L)
-        .createdBy(user)
-        .createdAt(null)
-        .updatedAt(null)
-        .status("running")
-        .log("Hello World! from test job!")
-        .build();
+        Job jobStarted = Job.builder()
+                .id(0L)
+                .createdBy(user)
+                .createdAt(null)
+                .updatedAt(null)
+                .status("running")
+                .log("Hello World! from test job!\nauthentication is not null")
+                .build();
 
-    Job jobFailed = Job.builder()
-        .id(0L)
-        .createdBy(user)
-        .createdAt(null)
-        .updatedAt(null)
-        .status("error")
-        .log("Hello World! from test job!\nFail!")
-        .build();
+        Job jobFailed = Job.builder()
+                .id(0L)
+                .createdBy(user)
+                .createdAt(null)
+                .updatedAt(null)
+                .status("error")
+                .log("Hello World! from test job!\nauthentication is not null\nFail!")
+                .build();
 
-    when(jobsRepository.save(any(Job.class))).thenReturn(jobStarted).thenReturn(jobFailed);
+        when(jobsRepository.save(any(Job.class))).thenReturn(jobStarted).thenReturn(jobFailed);
 
-    // act
-    MvcResult response = mockMvc.perform(post("/api/jobs/launch/testjob?fail=true&sleepMs=4000").with(csrf()))
-        .andExpect(status().isOk()).andReturn();
+        // act
+        MvcResult response = mockMvc.perform(post("/api/jobs/launch/testjob?fail=true&sleepMs=4000").with(csrf()))
+                .andExpect(status().isOk()).andReturn();
 
-    String responseString = response.getResponse().getContentAsString();
-    Job jobReturned = objectMapper.readValue(responseString, Job.class);
+        String responseString = response.getResponse().getContentAsString();
+        Job jobReturned = objectMapper.readValue(responseString, Job.class);
 
-    assertEquals("running", jobReturned.getStatus());
+        assertEquals("running", jobReturned.getStatus());
 
-    await().atMost(1, SECONDS)
-        .untilAsserted(() -> verify(jobsRepository, times(2)).save(eq(jobStarted)));
+        await().atMost(1, SECONDS)
+                .untilAsserted(() -> verify(jobsRepository, times(3)).save(eq(jobStarted)));
 
-    await().atMost(10, SECONDS)
-        .untilAsserted(() -> verify(jobsRepository, times(3)).save(eq(jobFailed)));
-  }
+        await().atMost(10, SECONDS)
+                .untilAsserted(() -> verify(jobsRepository, times(4)).save(eq(jobFailed)));
+    }
+
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void admin_can_launch_update_courses_job() throws Exception {
+        // act
+        MvcResult response = mockMvc.perform(post("/api/jobs/launch/updateCourses?quarterYYYYQ=20231&subjectArea=CMPSC").with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        String responseString = response.getResponse().getContentAsString();
+        log.info("responseString={}", responseString);
+        Job jobReturned = objectMapper.readValue(responseString, Job.class);
+
+        assertNotNull(jobReturned.getStatus());
+    }
+
 }

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/JobsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/JobsControllerTests.java
@@ -33,6 +33,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 
 import edu.ucsb.cs156.courses.ControllerTestCase;
+import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
 import edu.ucsb.cs156.courses.entities.User;
 import edu.ucsb.cs156.courses.jobs.UpdateCourseDataJobFactory;
 import edu.ucsb.cs156.courses.entities.Job;
@@ -65,6 +66,9 @@ public class JobsControllerTests extends ControllerTestCase {
 
     @MockBean
     UpdateCourseDataJobFactory updateCourseDataJobFactory;
+
+    @MockBean
+    ConvertedSectionCollection convertedSectionCollection;
 
     @WithMockUser(roles = { "ADMIN" })
     @Test

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/PSCourseControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/PSCourseControllerTests.java
@@ -11,6 +11,7 @@ import edu.ucsb.cs156.courses.entities.PersonalSchedule;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
@@ -36,6 +37,7 @@ import static org.mockito.Mockito.when;
 
 @WebMvcTest(controllers = PSCourseController.class)
 @Import(TestConfig.class)
+@AutoConfigureDataJpa
 public class PSCourseControllerTests extends ControllerTestCase {
 
     @MockBean

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesControllerTests.java
@@ -8,6 +8,7 @@ import edu.ucsb.cs156.courses.entities.User;
 import edu.ucsb.cs156.courses.repositories.PersonalScheduleRepository;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
@@ -32,6 +33,7 @@ import static org.mockito.Mockito.when;
 
 @WebMvcTest(controllers = PersonalSchedulesController.class)
 @Import(TestConfig.class)
+@AutoConfigureDataJpa
 public class PersonalSchedulesControllerTests extends ControllerTestCase {
 
     @MockBean

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/PersonalSectionsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/PersonalSectionsControllerTests.java
@@ -16,6 +16,7 @@ import edu.ucsb.cs156.courses.testconfig.TestConfig;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
@@ -57,6 +58,7 @@ import java.io.*;
 
 @WebMvcTest(controllers = {PersonalSectionsController.class})
 @Import(TestConfig.class)
+@AutoConfigureDataJpa
 public class PersonalSectionsControllerTests extends ControllerTestCase {
 
     @MockBean

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/SystemInfoControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/SystemInfoControllerTests.java
@@ -6,6 +6,7 @@ import edu.ucsb.cs156.courses.repositories.UserRepository;
 import edu.ucsb.cs156.courses.services.SystemInfoService;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -17,6 +18,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(controllers = SystemInfoController.class)
+@AutoConfigureDataJpa
 public class SystemInfoControllerTests extends ControllerTestCase {
 
   @MockBean

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumControllerTests.java
@@ -7,6 +7,7 @@ import edu.ucsb.cs156.courses.repositories.UserRepository;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
@@ -26,6 +27,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 @WebMvcTest(value = UCSBCurriculumController.class)
 @Import(SecurityConfig.class)
+@AutoConfigureDataJpa
 public class UCSBCurriculumControllerTests {
     private final Logger logger = LoggerFactory.getLogger(UCSBCurriculumControllerTests.class);
     private ObjectMapper mapper = new ObjectMapper();

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBSectionsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBSectionsControllerTests.java
@@ -7,6 +7,7 @@ import edu.ucsb.cs156.courses.repositories.UserRepository;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
@@ -26,6 +27,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 @WebMvcTest(value = UCSBSectionsController.class)
 @Import(SecurityConfig.class)
+@AutoConfigureDataJpa
 public class UCSBSectionsControllerTests {
     private final Logger logger = LoggerFactory.getLogger(UCSBSectionsControllerTests.class);
     private ObjectMapper mapper = new ObjectMapper();

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBSubjectsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBSubjectsControllerTests.java
@@ -9,6 +9,7 @@ import edu.ucsb.cs156.courses.entities.User;
 import edu.ucsb.cs156.courses.repositories.UCSBSubjectRepository;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
@@ -36,6 +37,7 @@ import static org.mockito.Mockito.doNothing;
 
 @WebMvcTest(controllers = UCSBSubjectsController.class)
 @Import(TestConfig.class)
+@AutoConfigureDataJpa
 public class UCSBSubjectsControllerTests extends ControllerTestCase {
 
     @MockBean

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/UserInfoControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/UserInfoControllerTests.java
@@ -6,6 +6,7 @@ import edu.ucsb.cs156.courses.repositories.UserRepository;
 import edu.ucsb.cs156.courses.testconfig.TestConfig;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
@@ -18,6 +19,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(controllers = UserInfoController.class)
 @Import(TestConfig.class)
+@AutoConfigureDataJpa
 public class UserInfoControllerTests extends ControllerTestCase {
 
   @MockBean

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/UsersControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/UsersControllerTests.java
@@ -6,6 +6,7 @@ import edu.ucsb.cs156.courses.repositories.UserRepository;
 import edu.ucsb.cs156.courses.testconfig.TestConfig;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
@@ -24,6 +25,7 @@ import java.util.Arrays;
 
 @WebMvcTest(controllers = UsersController.class)
 @Import(TestConfig.class)
+@AutoConfigureDataJpa
 public class UsersControllerTests extends ControllerTestCase {
 
   @MockBean

--- a/src/test/java/edu/ucsb/cs156/courses/documents/ConvertedSectionTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/documents/ConvertedSectionTests.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import org.bson.types.ObjectId;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,7 +19,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @ExtendWith(SpringExtension.class)
 @Import(ObjectMapper.class)
 @ContextConfiguration
-public class SectionTests {
+public class ConvertedSectionTests {
 
     @Autowired
     ObjectMapper mapper;
@@ -27,9 +28,10 @@ public class SectionTests {
     public void test_clone() throws JsonProcessingException, CloneNotSupportedException {
        List<ConvertedSection> cs = mapper.readValue(CoursePageFixtures.CONVERTED_SECTIONS_JSON_MATH5B, 
        new TypeReference<List<ConvertedSection>>() {});
-       Section s1 = cs.get(0).getSection();
-       Section s2 = (Section) s1.clone();
-       assertEquals(s1, s2);
-    }
 
+       ConvertedSection cs1 = cs.get(0);
+       cs1.set_id(new ObjectId());
+       ConvertedSection cs2 = (ConvertedSection) cs1.clone();
+       assertEquals(cs1, cs2);
+    }
 }

--- a/src/test/java/edu/ucsb/cs156/courses/documents/CourseInfoTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/documents/CourseInfoTests.java
@@ -18,7 +18,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @ExtendWith(SpringExtension.class)
 @Import(ObjectMapper.class)
 @ContextConfiguration
-public class SectionTests {
+public class CourseInfoTests {
 
     @Autowired
     ObjectMapper mapper;
@@ -27,9 +27,8 @@ public class SectionTests {
     public void test_clone() throws JsonProcessingException, CloneNotSupportedException {
        List<ConvertedSection> cs = mapper.readValue(CoursePageFixtures.CONVERTED_SECTIONS_JSON_MATH5B, 
        new TypeReference<List<ConvertedSection>>() {});
-       Section s1 = cs.get(0).getSection();
-       Section s2 = (Section) s1.clone();
-       assertEquals(s1, s2);
+       CourseInfo c1 = cs.get(0).getCourseInfo();
+       CourseInfo c2 = (CourseInfo) c1.clone();
+       assertEquals(c1, c2);
     }
-
 }

--- a/src/test/java/edu/ucsb/cs156/courses/documents/InstructorTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/documents/InstructorTests.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs156.courses.documents;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.List;
 
@@ -18,18 +19,26 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @ExtendWith(SpringExtension.class)
 @Import(ObjectMapper.class)
 @ContextConfiguration
-public class SectionTests {
+public class InstructorTests {
 
     @Autowired
     ObjectMapper mapper;
 
     @Test
     public void test_clone() throws JsonProcessingException, CloneNotSupportedException {
-       List<ConvertedSection> cs = mapper.readValue(CoursePageFixtures.CONVERTED_SECTIONS_JSON_MATH5B, 
-       new TypeReference<List<ConvertedSection>>() {});
-       Section s1 = cs.get(0).getSection();
-       Section s2 = (Section) s1.clone();
-       assertEquals(s1, s2);
+        Instructor i1  = Instructor.builder()
+            .instructor("John Doe")
+            .functionCode("P")
+            .build();
+
+        Instructor i2 = (Instructor) i1.clone();
+        assertEquals(i1, i2);
     }
 
+    @Test
+    public void test_noArgsConstructor()  {
+        Instructor i1  = new Instructor();
+        assertNull(i1.getInstructor());
+        assertNull(i1.getFunctionCode());
+    }
 }

--- a/src/test/java/edu/ucsb/cs156/courses/documents/SectionTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/documents/SectionTests.java
@@ -1,0 +1,34 @@
+package edu.ucsb.cs156.courses.documents;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@Import(ObjectMapper.class)
+@ContextConfiguration
+public class SectionTests {
+
+    @Autowired
+    ObjectMapper mapper;
+
+    @Test
+    public void test_clone() throws JsonProcessingException {
+       List<ConvertedSection> cs = mapper.readValue(CoursePageFixtures.CONVERTED_SECTIONS_JSON_MATH5B, 
+       new TypeReference<List<ConvertedSection>>() {});
+       Section s1 = cs.get(0).getSection();
+       Section s2 = s1.clone();
+       assertEquals(s1, s2);
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/courses/documents/TimeLocationTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/documents/TimeLocationTests.java
@@ -18,18 +18,23 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @ExtendWith(SpringExtension.class)
 @Import(ObjectMapper.class)
 @ContextConfiguration
-public class SectionTests {
+public class TimeLocationTests {
 
     @Autowired
     ObjectMapper mapper;
 
     @Test
     public void test_clone() throws JsonProcessingException, CloneNotSupportedException {
-       List<ConvertedSection> cs = mapper.readValue(CoursePageFixtures.CONVERTED_SECTIONS_JSON_MATH5B, 
-       new TypeReference<List<ConvertedSection>>() {});
-       Section s1 = cs.get(0).getSection();
-       Section s2 = (Section) s1.clone();
-       assertEquals(s1, s2);
-    }
+        TimeLocation tl1 = TimeLocation.builder()
+                .room("123")
+                .building("Bren Hall")
+                .roomCapacity("16")
+                .days("MWF")
+                .beginTime("10:00")
+                .endTime("11:00")
+                .build();
 
+        TimeLocation tl2 = (TimeLocation) tl1.clone();
+        assertEquals(tl1, tl2);
+    }
 }

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/TestJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/TestJobTests.java
@@ -1,0 +1,65 @@
+package edu.ucsb.cs156.courses.jobs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import edu.ucsb.cs156.courses.entities.Job;
+import edu.ucsb.cs156.courses.services.jobs.JobContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration 
+public class TestJobTests {
+
+    @Test
+    void test_log_output_with_no_user() throws Exception {
+
+        // Arrange
+
+        Job jobStarted = Job.builder().build();
+
+        JobContext ctx = new JobContext(null, jobStarted);
+
+        // Act
+        TestJob testJob = TestJob.builder()
+                .sleepMs(0)
+                .fail(false)
+                .build();
+        testJob.accept(ctx);
+
+        String expected = """
+            Hello World! from test job!
+            authentication is null
+            Goodbye from test job!""";
+        // Assert
+        assertEquals(expected, jobStarted.getLog());
+    }
+
+    @Test
+    @WithMockUser(roles = { "ADMIN" })
+    void test_log_output_with_mock_user() throws Exception {
+        // Arrange
+
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+
+        // Act
+        TestJob testJob = TestJob.builder()
+                .sleepMs(0)
+                .fail(false)
+                .build();
+        testJob.accept(ctx);
+
+        String expected = """
+                Hello World! from test job!
+                authentication is not null
+                Goodbye from test job!""";
+        // Assert
+        assertEquals(expected, jobStarted.getLog());
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobFactoryTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobFactoryTests.java
@@ -1,0 +1,41 @@
+package edu.ucsb.cs156.courses.jobs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+
+import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
+
+@RestClientTest(UpdateCourseDataJobFactory.class)
+@AutoConfigureDataJpa
+public class UpdateCourseDataJobFactoryTests {
+
+    @MockBean
+    UCSBCurriculumService ucsbCurriculumService;
+
+    @Autowired
+    UpdateCourseDataJobFactory updateCourseDataJobFactory;
+
+    @Test
+    void test_create() throws Exception {
+
+        // Act
+
+        UpdateCourseDataJob updateCourseDataJob = updateCourseDataJobFactory.create("CMPSC", "20211");
+
+        // Assert
+
+        assertEquals("CMPSC",updateCourseDataJob.getSubjectArea());
+        assertEquals("20211",updateCourseDataJob.getQuarterYYYYQ());
+        assertEquals(ucsbCurriculumService,updateCourseDataJob.getUcsbCurriculumService());
+
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobFactoryTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobFactoryTests.java
@@ -12,6 +12,7 @@ import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 
+import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
 
 @RestClientTest(UpdateCourseDataJobFactory.class)
@@ -20,6 +21,9 @@ public class UpdateCourseDataJobFactoryTests {
 
     @MockBean
     UCSBCurriculumService ucsbCurriculumService;
+
+    @MockBean
+    ConvertedSectionCollection convertedSectionCollection;
 
     @Autowired
     UpdateCourseDataJobFactory updateCourseDataJobFactory;
@@ -36,6 +40,7 @@ public class UpdateCourseDataJobFactoryTests {
         assertEquals("CMPSC",updateCourseDataJob.getSubjectArea());
         assertEquals("20211",updateCourseDataJob.getQuarterYYYYQ());
         assertEquals(ucsbCurriculumService,updateCourseDataJob.getUcsbCurriculumService());
+        assertEquals(convertedSectionCollection,updateCourseDataJob.getConvertedSectionCollection());
 
     }
 }

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobTests.java
@@ -2,26 +2,26 @@ package edu.ucsb.cs156.courses.jobs;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
-import javax.xml.transform.Result;
 
-import org.h2.command.dml.Update;
-import org.hibernate.boot.jaxb.hbm.spi.SubEntityInfo;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
 import edu.ucsb.cs156.courses.documents.ConvertedSection;
@@ -30,22 +30,24 @@ import edu.ucsb.cs156.courses.documents.CoursePageFixtures;
 import edu.ucsb.cs156.courses.entities.Job;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
 import edu.ucsb.cs156.courses.services.jobs.JobContext;
-import edu.ucsb.cs156.courses.testconfig.TestConfig;
 
 
 @ExtendWith(SpringExtension.class)
+@Import(ObjectMapper.class)
 @ContextConfiguration
 public class UpdateCourseDataJobTests {
 
     @Mock
     UCSBCurriculumService ucsbCurriculumService;
 
-
     @Mock
     ConvertedSectionCollection convertedSectionCollection;
 
+    @Autowired
+    ObjectMapper mapper;
+
     @Test
-    void test_log_output() throws Exception {
+    void test_log_output_success() throws Exception {
 
         // Arrange
 
@@ -73,9 +75,113 @@ public class UpdateCourseDataJobTests {
                 Updating courses for [CMPSC 20211]
                 Found 14 sections
                 Storing in MongoDB Collection...
-                14 sections saved in MongoDB Collection...
+                14 new sections saved, 0 sections updated, 0 errors
                 Courses for [CMPSC 20211] have been updated""";
 
         assertEquals(expected, jobStarted.getLog());
     }
+
+    @Test
+    void test_log_output_with_updates() throws Exception {
+
+        // Arrange
+
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+
+        String coursePageJson = CoursePageFixtures.COURSE_PAGE_JSON_MATH3B;
+        CoursePage coursePage = CoursePage.fromJSON(coursePageJson);
+
+        List<ConvertedSection> convertedSections = coursePage.convertedSections();
+
+        List<ConvertedSection> listWithTwoOrigOneDuplicate = new ArrayList<>();
+
+        ConvertedSection section0 = convertedSections.get(0);
+        ConvertedSection section1 = convertedSections.get(1);
+        
+
+        listWithTwoOrigOneDuplicate.add(section0);
+        listWithTwoOrigOneDuplicate.add(section1);
+        listWithTwoOrigOneDuplicate.add(section0);
+      
+        UpdateCourseDataJob updateCourseDataJob = new UpdateCourseDataJob("MATH", "20211", ucsbCurriculumService, convertedSectionCollection);
+
+        Optional<ConvertedSection> section0Optional = Optional.of(section0);
+        Optional<ConvertedSection> emptyOptional = Optional.empty();
+
+        when(ucsbCurriculumService.getConvertedSections(eq("MATH"), eq("20211"), eq("A"))).thenReturn(listWithTwoOrigOneDuplicate);
+        when(convertedSectionCollection.findOneByQuarterAndEnrollCode(
+            eq(section0.getCourseInfo().getQuarter()), 
+            eq(section0.getSection().getEnrollCode())))
+            .thenReturn(emptyOptional).thenReturn(section0Optional);
+        when(convertedSectionCollection.findOneByQuarterAndEnrollCode(
+                eq(section1.getCourseInfo().getQuarter()), 
+                eq(section1.getSection().getEnrollCode())))
+                .thenReturn(emptyOptional);
+        when(convertedSectionCollection.saveAll(any())).thenReturn(null);
+
+        // Act
+
+        updateCourseDataJob.accept(ctx);
+
+        // Assert
+
+        String expected = """
+                Updating courses for [MATH 20211]
+                Found 3 sections
+                Storing in MongoDB Collection...
+                2 new sections saved, 1 sections updated, 0 errors
+                Courses for [MATH 20211] have been updated""";
+
+        assertEquals(expected, jobStarted.getLog());
+    }
+
+    @Test
+    void test_log_output_with_errors() throws Exception {
+
+        // Arrange
+
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+
+        String coursePageJson = CoursePageFixtures.COURSE_PAGE_JSON_MATH3B;
+        CoursePage coursePage = CoursePage.fromJSON(coursePageJson);
+
+        List<ConvertedSection> convertedSections = coursePage.convertedSections();
+
+        List<ConvertedSection> listWithOneSection = new ArrayList<>();
+
+        ConvertedSection section0 = convertedSections.get(0);
+        
+        listWithOneSection.add(section0);
+       
+      
+        UpdateCourseDataJob updateCourseDataJob = new UpdateCourseDataJob("MATH", "20211", ucsbCurriculumService, convertedSectionCollection);
+
+        Optional<ConvertedSection> section0Optional = Optional.of(section0);
+        Optional<ConvertedSection> emptyOptional = Optional.empty();
+
+        when(ucsbCurriculumService.getConvertedSections(eq("MATH"), eq("20211"), eq("A"))).thenReturn(listWithOneSection);
+        when(convertedSectionCollection.findOneByQuarterAndEnrollCode(
+            eq(section0.getCourseInfo().getQuarter()), 
+            eq(section0.getSection().getEnrollCode())))
+            .thenThrow(new IllegalArgumentException("Testing Exception Handling!"));
+       
+        // Act
+
+        updateCourseDataJob.accept(ctx);
+
+        // Assert
+
+        String expected = """
+                Updating courses for [MATH 20211]
+                Found 1 sections
+                Storing in MongoDB Collection...
+                Error saving section: Testing Exception Handling!
+                0 new sections saved, 0 sections updated, 1 errors
+                Courses for [MATH 20211] have been updated""";
+
+        assertEquals(expected, jobStarted.getLog());
+    }
+
 }

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobTests.java
@@ -1,0 +1,36 @@
+package edu.ucsb.cs156.courses.jobs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import edu.ucsb.cs156.courses.entities.Job;
+import edu.ucsb.cs156.courses.services.jobs.JobContext;
+
+public class UpdateCourseDataJobTests {
+    @Test
+    void test_log_output() throws Exception {
+
+        // Arrange
+
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+
+        // Act
+        UpdateCourseDataJob updateCourseDataJob = UpdateCourseDataJob.builder()
+                .quarterYYYYQ("20231")
+                .subjectArea("CMPSC")
+                .build();
+        updateCourseDataJob.accept(ctx);
+
+        // Assert
+
+        String expected = """
+                Updating courses for [CMPSC 20231]
+                This is where the code to pull data from the UCSB API would go
+                This is where the code to store that data in MongoDB would go
+                Courses for [CMPSC 20231] have been updated""";
+
+        assertEquals(expected, jobStarted.getLog());
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobTests.java
@@ -1,10 +1,14 @@
 package edu.ucsb.cs156.courses.jobs;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+
+import javax.xml.transform.Result;
 
 import org.h2.command.dml.Update;
 import org.hibernate.boot.jaxb.hbm.spi.SubEntityInfo;
@@ -19,6 +23,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
 import edu.ucsb.cs156.courses.documents.ConvertedSection;
 import edu.ucsb.cs156.courses.documents.CoursePage;
 import edu.ucsb.cs156.courses.documents.CoursePageFixtures;
@@ -35,6 +40,10 @@ public class UpdateCourseDataJobTests {
     @Mock
     UCSBCurriculumService ucsbCurriculumService;
 
+
+    @Mock
+    ConvertedSectionCollection convertedSectionCollection;
+
     @Test
     void test_log_output() throws Exception {
 
@@ -48,9 +57,10 @@ public class UpdateCourseDataJobTests {
 
         List<ConvertedSection> result = coursePage.convertedSections();
 
-        UpdateCourseDataJob updateCourseDataJob = new UpdateCourseDataJob("CMPSC", "20211", ucsbCurriculumService);
+        UpdateCourseDataJob updateCourseDataJob = new UpdateCourseDataJob("CMPSC", "20211", ucsbCurriculumService, convertedSectionCollection);
 
         when(ucsbCurriculumService.getConvertedSections(eq("CMPSC"), eq("20211"), eq("A"))).thenReturn(result);
+        when(convertedSectionCollection.saveAll(any())).thenReturn(result);
 
 
         // Act
@@ -62,7 +72,8 @@ public class UpdateCourseDataJobTests {
         String expected = """
                 Updating courses for [CMPSC 20211]
                 Found 14 sections
-                This is where the code to store that data in MongoDB would go
+                Storing in MongoDB Collection...
+                14 sections saved in MongoDB Collection...
                 Courses for [CMPSC 20211] have been updated""";
 
         assertEquals(expected, jobStarted.getLog());

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobTests.java
@@ -12,7 +12,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -29,10 +28,10 @@ import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
 import edu.ucsb.cs156.courses.documents.ConvertedSection;
 import edu.ucsb.cs156.courses.documents.CoursePage;
 import edu.ucsb.cs156.courses.documents.CoursePageFixtures;
+import edu.ucsb.cs156.courses.documents.Section;
 import edu.ucsb.cs156.courses.entities.Job;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
 import edu.ucsb.cs156.courses.services.jobs.JobContext;
-
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration
@@ -57,11 +56,11 @@ public class UpdateCourseDataJobTests {
 
         List<ConvertedSection> result = coursePage.convertedSections();
 
-        UpdateCourseDataJob updateCourseDataJob = new UpdateCourseDataJob("CMPSC", "20211", ucsbCurriculumService, convertedSectionCollection);
+        UpdateCourseDataJob updateCourseDataJob = new UpdateCourseDataJob("CMPSC", "20211", ucsbCurriculumService,
+                convertedSectionCollection);
 
         when(ucsbCurriculumService.getConvertedSections(eq("CMPSC"), eq("20211"), eq("A"))).thenReturn(result);
         when(convertedSectionCollection.saveAll(any())).thenReturn(result);
-
 
         // Act
 
@@ -96,24 +95,25 @@ public class UpdateCourseDataJobTests {
 
         ConvertedSection section0 = convertedSections.get(0);
         ConvertedSection section1 = convertedSections.get(1);
-        
 
         listWithTwoOrigOneDuplicate.add(section0);
         listWithTwoOrigOneDuplicate.add(section1);
         listWithTwoOrigOneDuplicate.add(section0);
-      
-        UpdateCourseDataJob updateCourseDataJob = new UpdateCourseDataJob("MATH", "20211", ucsbCurriculumService, convertedSectionCollection);
+
+        UpdateCourseDataJob updateCourseDataJob = new UpdateCourseDataJob("MATH", "20211", ucsbCurriculumService,
+                convertedSectionCollection);
 
         Optional<ConvertedSection> section0Optional = Optional.of(section0);
         Optional<ConvertedSection> emptyOptional = Optional.empty();
 
-        when(ucsbCurriculumService.getConvertedSections(eq("MATH"), eq("20211"), eq("A"))).thenReturn(listWithTwoOrigOneDuplicate);
+        when(ucsbCurriculumService.getConvertedSections(eq("MATH"), eq("20211"), eq("A")))
+                .thenReturn(listWithTwoOrigOneDuplicate);
         when(convertedSectionCollection.findOneByQuarterAndEnrollCode(
-            eq(section0.getCourseInfo().getQuarter()), 
-            eq(section0.getSection().getEnrollCode())))
-            .thenReturn(emptyOptional).thenReturn(section0Optional);
+                eq(section0.getCourseInfo().getQuarter()),
+                eq(section0.getSection().getEnrollCode())))
+                .thenReturn(emptyOptional).thenReturn(section0Optional);
         when(convertedSectionCollection.findOneByQuarterAndEnrollCode(
-                eq(section1.getCourseInfo().getQuarter()), 
+                eq(section1.getCourseInfo().getQuarter()),
                 eq(section1.getSection().getEnrollCode())))
                 .thenReturn(emptyOptional);
         when(convertedSectionCollection.saveAll(any())).thenReturn(null);
@@ -150,21 +150,22 @@ public class UpdateCourseDataJobTests {
         List<ConvertedSection> listWithOneSection = new ArrayList<>();
 
         ConvertedSection section0 = convertedSections.get(0);
-        
+
         listWithOneSection.add(section0);
-       
-      
-        UpdateCourseDataJob updateCourseDataJob = new UpdateCourseDataJob("MATH", "20211", ucsbCurriculumService, convertedSectionCollection);
+
+        UpdateCourseDataJob updateCourseDataJob = new UpdateCourseDataJob("MATH", "20211", ucsbCurriculumService,
+                convertedSectionCollection);
 
         Optional<ConvertedSection> section0Optional = Optional.of(section0);
         Optional<ConvertedSection> emptyOptional = Optional.empty();
 
-        when(ucsbCurriculumService.getConvertedSections(eq("MATH"), eq("20211"), eq("A"))).thenReturn(listWithOneSection);
+        when(ucsbCurriculumService.getConvertedSections(eq("MATH"), eq("20211"), eq("A")))
+                .thenReturn(listWithOneSection);
         when(convertedSectionCollection.findOneByQuarterAndEnrollCode(
-            eq(section0.getCourseInfo().getQuarter()), 
-            eq(section0.getSection().getEnrollCode())))
-            .thenThrow(new IllegalArgumentException("Testing Exception Handling!"));
-       
+                eq(section0.getCourseInfo().getQuarter()),
+                eq(section0.getSection().getEnrollCode())))
+                .thenThrow(new IllegalArgumentException("Testing Exception Handling!"));
+
         // Act
 
         updateCourseDataJob.accept(ctx);
@@ -198,25 +199,26 @@ public class UpdateCourseDataJobTests {
         List<ConvertedSection> listWithUpdatedSection = new ArrayList<>();
 
         ConvertedSection section0 = convertedSections.get(0);
-       
+        String quarter = section0.getCourseInfo().getQuarter();
+        String enrollCode = section0.getSection().getEnrollCode();
+
         int oldEnrollment = section0.getSection().getEnrolledTotal();
 
-        ConvertedSection updatedSection = new ConvertedSection();
-        updatedSection.setCourseInfo(section0.getCourseInfo());
-        updatedSection.setSection(section0.getSection().clone());
+        ConvertedSection updatedSection = (ConvertedSection) section0.clone();
+        updatedSection.getCourseInfo().setTitle("New Title");
         updatedSection.getSection().setEnrolledTotal(oldEnrollment + 1);
         listWithUpdatedSection.add(updatedSection);
 
-        UpdateCourseDataJob updateCourseDataJob = new UpdateCourseDataJob("MATH", "20211", ucsbCurriculumService, convertedSectionCollection);
+        UpdateCourseDataJob updateCourseDataJob = new UpdateCourseDataJob("MATH", "20211", ucsbCurriculumService,
+                convertedSectionCollection);
 
         Optional<ConvertedSection> section0Optional = Optional.of(section0);
 
-        when(ucsbCurriculumService.getConvertedSections(eq("MATH"), eq("20211"), eq("A"))).thenReturn(listWithUpdatedSection);
-        when(convertedSectionCollection.findOneByQuarterAndEnrollCode(
-            eq(section0.getCourseInfo().getQuarter()), 
-            eq(section0.getSection().getEnrollCode())))
-            .thenReturn(section0Optional);
-       
+        when(ucsbCurriculumService.getConvertedSections(eq("MATH"), eq("20211"), eq("A")))
+                .thenReturn(listWithUpdatedSection);
+        when(convertedSectionCollection.findOneByQuarterAndEnrollCode(eq(quarter), eq(enrollCode)))
+                .thenReturn(section0Optional);
+
         // Act
 
         updateCourseDataJob.accept(ctx);
@@ -230,9 +232,10 @@ public class UpdateCourseDataJobTests {
                 0 new sections saved, 1 sections updated, 0 errors
                 Courses for [MATH 20211] have been updated""";
 
-        assertEquals(expected, jobStarted.getLog());
+         assertEquals(expected, jobStarted.getLog());
 
-        verify(convertedSectionCollection, times(1)).save(updatedSection);
+       verify(convertedSectionCollection, times(1)).findOneByQuarterAndEnrollCode(eq(quarter), eq(enrollCode));
+       verify(convertedSectionCollection, times(1)).save(updatedSection);
 
     }
 

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobTests.java
@@ -1,13 +1,40 @@
 package edu.ucsb.cs156.courses.jobs;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
 
+import java.util.List;
+
+import org.h2.command.dml.Update;
+import org.hibernate.boot.jaxb.hbm.spi.SubEntityInfo;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import edu.ucsb.cs156.courses.documents.ConvertedSection;
+import edu.ucsb.cs156.courses.documents.CoursePage;
+import edu.ucsb.cs156.courses.documents.CoursePageFixtures;
 import edu.ucsb.cs156.courses.entities.Job;
+import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
 import edu.ucsb.cs156.courses.services.jobs.JobContext;
+import edu.ucsb.cs156.courses.testconfig.TestConfig;
 
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration
 public class UpdateCourseDataJobTests {
+
+    @Mock
+    UCSBCurriculumService ucsbCurriculumService;
+
     @Test
     void test_log_output() throws Exception {
 
@@ -16,20 +43,27 @@ public class UpdateCourseDataJobTests {
         Job jobStarted = Job.builder().build();
         JobContext ctx = new JobContext(null, jobStarted);
 
+        String coursePageJson = CoursePageFixtures.COURSE_PAGE_JSON_MATH3B;
+        CoursePage coursePage = CoursePage.fromJSON(coursePageJson);
+
+        List<ConvertedSection> result = coursePage.convertedSections();
+
+        UpdateCourseDataJob updateCourseDataJob = new UpdateCourseDataJob("CMPSC", "20211", ucsbCurriculumService);
+
+        when(ucsbCurriculumService.getConvertedSections(eq("CMPSC"), eq("20211"), eq("A"))).thenReturn(result);
+
+
         // Act
-        UpdateCourseDataJob updateCourseDataJob = UpdateCourseDataJob.builder()
-                .quarterYYYYQ("20231")
-                .subjectArea("CMPSC")
-                .build();
+
         updateCourseDataJob.accept(ctx);
 
         // Assert
 
         String expected = """
-                Updating courses for [CMPSC 20231]
-                This is where the code to pull data from the UCSB API would go
+                Updating courses for [CMPSC 20211]
+                Found 14 sections
                 This is where the code to store that data in MongoDB would go
-                Courses for [CMPSC 20231] have been updated""";
+                Courses for [CMPSC 20211] have been updated""";
 
         assertEquals(expected, jobStarted.getLog());
     }

--- a/src/test/java/edu/ucsb/cs156/courses/services/UCSBCurriculumServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/services/UCSBCurriculumServiceTests.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
@@ -32,6 +33,7 @@ import edu.ucsb.cs156.courses.documents.CoursePageFixtures;
 import edu.ucsb.cs156.courses.documents.SectionFixtures;
 
 @RestClientTest(UCSBCurriculumService.class)
+@AutoConfigureDataJpa
 public class UCSBCurriculumServiceTests {
 
     @Value("${app.ucsb.api.consumer_key}")

--- a/src/test/java/edu/ucsb/cs156/courses/services/UCSBSubjectsServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/services/UCSBSubjectsServiceTests.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
 import org.springframework.test.web.client.MockRestServiceServer;
 
@@ -28,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 
 @RestClientTest(UCSBSubjectsService.class)
+@AutoConfigureDataJpa
 class UCSBSubjectsServiceTests {
 
   @Autowired


### PR DESCRIPTION
# Overview

In this PR, we roll out a new feature that allows admins to update a MongoDB database with course information via an asynchronous job.

The intent is for this new feature to open up several new lines of development, especially for the -1 teams on courses:

Especially, this opens up the possibility to develop searches that are not supported by the UCSB Courses API, such as search by course (over multiple quarters) and search by instructor (over multiple quarters.)

It also opens up the possibility to add similar jobs that will:
* load all subject areas in a given quarter.
* load all subject areas over a range of quarters.

# User Story

As an admin
* I can specify a quarter and a subject area and launch a job that loads data for that quarter and subject area into the MongoDB database
* So that developers can work on queries that require such a database

# How to Test / Use this feature

Here's an outline, followed by some animations

1. Configure your app for a fresh MongoDB database; go see the data that is loaded 
2. Login as an admin
3. Go to Admin / Load Subjects to make sure that the subject areas are loaded (this only needs to be done once)
4. Go to Admin / Manage Jobs
5. Specify Update Course Data
6. Specify quarter and subject area
7. Click "Update"
8. Wait for job to finish.  It should report how many courses were loaded or updated
9. See results in MongoDb 


Step 1: See MongoDB data:

This animation shows how to look at and do queries on MongoDB data:

![see-mongodb-data](https://user-images.githubusercontent.com/1119017/203417379-ae587495-b3c5-4afd-87b4-cbb8219124fe.gif)


Steps 2-3: Login as Admin, Load Subjects

![load-subjects](https://user-images.githubusercontent.com/1119017/203416752-1f6838d3-86d5-499d-94d0-17e3567b8751.gif)

Steps: 4-8:  Running the job and waiting for it to finish (in this case, MATH courses in W23):

![load-course-data](https://user-images.githubusercontent.com/1119017/203418212-9a0c075c-03c9-4d0f-b964-16992b45fdbf.gif)

Step 9: See the MATH courses 

The query is:

```
{ 'courseInfo.quarter' : '20231', 'courseInfo.courseId': { $regex: /MATH/ }}
```

![see-math-courses](https://user-images.githubusercontent.com/1119017/203419046-3b50d57b-25be-4b2c-bb96-69d56fd7ed38.gif)
