### PR TITLE
HY & AG - Personal schedule dropdown component

### DIFF
--- a/frontend/src/fixtures/personalSchedulesFixtures.js
+++ b/frontend/src/fixtures/personalSchedulesFixtures.js
@@ -10,7 +10,7 @@ const personalSchedulesFixtures = {
         "id": 1,
         "name": "TestNameA",
         "description": "TestDescriptionA",
-        "quarter": "W08"
+        "quarter": "20221"
         }
     ],
     threePersonalSchedules: [
@@ -18,19 +18,19 @@ const personalSchedulesFixtures = {
             "id": 1,
             "name": "TestName1",
             "description": "TestDescription1",
-            "quarter": "S08"
+            "quarter": "20222"
         },
         {
             "id": 2,
             "name": "TestName2",
             "description": "TestDescription2",
-            "quarter": "W09"
+            "quarter": "20223"
         },
         {
             "id": 3,
             "name": "TestName3",
             "description": "TestDescription3",
-            "quarter": "S12"
+            "quarter": "20224"
         }
     ]
 };

--- a/frontend/src/fixtures/personalSchedulesFixtures.js
+++ b/frontend/src/fixtures/personalSchedulesFixtures.js
@@ -5,7 +5,15 @@ const personalSchedulesFixtures = {
         "description": "TestDescription",
         "quarter": "W08"
     },
-    twoPersonalSchedules: [
+    onePersonalScheduleArray: [
+        {
+        "id": 1,
+        "name": "TestNameA",
+        "description": "TestDescriptionA",
+        "quarter": "W08"
+        }
+    ],
+    threePersonalSchedules: [
         {
             "id": 1,
             "name": "TestName1",

--- a/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
@@ -7,9 +7,7 @@ import { quarterRange } from "main/utils/quarterUtilities";
 import { useSystemInfo } from "main/utils/systemInfo";
 import SingleQuarterDropdown from "../Quarters/SingleQuarterDropdown";
 import SingleSubjectDropdown from "../Subjects/SingleSubjectDropdown";
-
 import SinglePersonalScheduleDropdown from "../PersonalSchedules/SinglePersonalScheduleDropdown"; //
-
 import SingleLevelDropdown from "../Levels/SingleLevelDropdown";
 import { useBackendMutation, useBackend } from "main/utils/useBackend";
 
@@ -35,9 +33,7 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
 
   // Stryker disable all : not sure how to test/mock local storage
   const localSubject = localStorage.getItem("BasicSearch.Subject");
-
   const localPersonalSchedule = localStorage.getItem("BasicSearch.PersonalSchedule"); //
-
   const localQuarter = localStorage.getItem("BasicSearch.Quarter");
   const localLevel = localStorage.getItem("BasicSearch.CourseLevel");
 
@@ -66,15 +62,12 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
   const [quarter, setQuarter] = useState(localQuarter || quarters[0].yyyyq);
   const [subject, setSubject] = useState(localSubject || {});
   const [subjects, setSubjects] = useState([]);
-
   const [personalSchedule, setPersonalSchedule] = useState(localPersonalSchedule || {}); //
-  // const [personalSchedules, setPersonalSchedules] = useState([]); //
-
   const [level, setLevel] = useState(localLevel || "U");
 
   const handleSubmit = (event) => {
     event.preventDefault();
-    fetchJSON(event, { quarter, subject, level });
+    fetchJSON(event, { quarter, subject, level }); //add personalSchedule param?
   };
 
   // Stryker disable all : Stryker is testing by changing the padding to 0. But this is simply a visual optimization as it makes it look better

--- a/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
@@ -7,6 +7,9 @@ import { quarterRange } from "main/utils/quarterUtilities";
 import { useSystemInfo } from "main/utils/systemInfo";
 import SingleQuarterDropdown from "../Quarters/SingleQuarterDropdown";
 import SingleSubjectDropdown from "../Subjects/SingleSubjectDropdown";
+
+import SinglePersonalScheduleDropdown from "../PersonalSchedules/SinglePersonalScheduleDropdown"; //
+
 import SingleLevelDropdown from "../Levels/SingleLevelDropdown";
 import { useBackendMutation } from "main/utils/useBackend";
 
@@ -23,6 +26,9 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
 
   // Stryker disable all : not sure how to test/mock local storage
   const localSubject = localStorage.getItem("BasicSearch.Subject");
+
+  const localPersonalSchedule = localStorage.getItem("BasicSearch.PersonalSchedule"); //
+
   const localQuarter = localStorage.getItem("BasicSearch.Quarter");
   const localLevel = localStorage.getItem("BasicSearch.CourseLevel");
 
@@ -32,8 +38,18 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
     params: {},
   });
 
+  const getObjectToAxiosParams2 = () => ({ //
+    url: "/api/personalschedules/all",
+    method: "GET",
+    params: {},
+  });
+
   const onSuccess = (listSubjects) => {
     setSubjects(listSubjects);
+  };
+
+  const onSuccess2 = (listPersonalSchedules) => { //
+    setPersonalSchedules(listPersonalSchedules);
   };
 
 
@@ -45,19 +61,31 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
     []
   );
 
+  const getMutation2 = useBackendMutation( //
+    getObjectToAxiosParams2,
+    { onSuccess2 },
+    // Stryker disable next-line all : hard to set up test for caching
+    []
+  );
+
   useEffect(() => {
     getMutation.mutate();
+    getMutation2.mutate(); //
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const [quarter, setQuarter] = useState(localQuarter || quarters[0].yyyyq);
   const [subject, setSubject] = useState(localSubject || {});
   const [subjects, setSubjects] = useState([]);
+
+  const [personalSchedule, setPersonalSchedule] = useState(localPersonalSchedule || {}); //
+  const [personalSchedules, setPersonalSchedules] = useState([]); //
+
   const [level, setLevel] = useState(localLevel || "U");
 
   const handleSubmit = (event) => {
     event.preventDefault();
-    fetchJSON(event, { quarter, subject, level });
+    fetchJSON(event, { quarter, subject, level, personalSchedule });
   };
 
   // Stryker disable all : Stryker is testing by changing the padding to 0. But this is simply a visual optimization as it makes it look better
@@ -87,6 +115,14 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
               level={level}
               setLevel={setLevel}
               controlId={"BasicSearch.Level"}
+            />
+          </Col>
+          <Col md="auto">
+            <SinglePersonalScheduleDropdown
+              personalSchedules={personalSchedules}
+              personalSchedule={personalSchedule}
+              setPersonalSchedule={setPersonalSchedule}
+              controlId={"BasicSearch.PersonalSchedule"}
             />
           </Col>
         </Row>

--- a/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
@@ -11,7 +11,7 @@ import SingleSubjectDropdown from "../Subjects/SingleSubjectDropdown";
 import SinglePersonalScheduleDropdown from "../PersonalSchedules/SinglePersonalScheduleDropdown"; //
 
 import SingleLevelDropdown from "../Levels/SingleLevelDropdown";
-import { useBackendMutation } from "main/utils/useBackend";
+import { useBackendMutation, useBackend } from "main/utils/useBackend";
 
 const BasicCourseSearchForm = ({ fetchJSON }) => {
 
@@ -23,6 +23,15 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
   // Stryker enable OptionalChaining
 
   const quarters = quarterRange(startQtr, endQtr);
+
+  const { data: personalSchedules, error: _error, status: _status } =
+  useBackend(
+      // Stryker disable next-line all : don't test internal caching of React Query
+      ["/api/personalschedules/all"],
+      { method: "GET", url: "/api/personalschedules/all" },
+      []
+  );
+
 
   // Stryker disable all : not sure how to test/mock local storage
   const localSubject = localStorage.getItem("BasicSearch.Subject");
@@ -38,19 +47,19 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
     params: {},
   });
 
-  const getObjectToAxiosParams2 = () => ({ //
-    url: "/api/personalschedules/all",
-    method: "GET",
-    params: {},
-  });
+  // const getObjectToAxiosParams2 = () => ({ //
+  //   url: "/api/personalschedules/all",
+  //   method: "GET",
+  //   params: {},
+  // });
 
   const onSuccess = (listSubjects) => {
     setSubjects(listSubjects);
   };
 
-  const onSuccess2 = (listPersonalSchedules) => { //
-    setPersonalSchedules(listPersonalSchedules);
-  };
+  // const onSuccess2 = (listPersonalSchedules) => { //
+  //   setPersonalSchedules(listPersonalSchedules);
+  // };
 
 
 
@@ -61,16 +70,16 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
     []
   );
 
-  const getMutation2 = useBackendMutation( //
-    getObjectToAxiosParams2,
-    { onSuccess2 },
-    // Stryker disable next-line all : hard to set up test for caching
-    []
-  );
+  // const getMutation2 = useBackendMutation( //
+  //   getObjectToAxiosParams2,
+  //   { onSuccess2 },
+  //   // Stryker disable next-line all : hard to set up test for caching
+  //   []
+  // );
 
   useEffect(() => {
     getMutation.mutate();
-    getMutation2.mutate(); //
+    // getMutation2.mutate(); //
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -79,7 +88,7 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
   const [subjects, setSubjects] = useState([]);
 
   const [personalSchedule, setPersonalSchedule] = useState(localPersonalSchedule || {}); //
-  const [personalSchedules, setPersonalSchedules] = useState([]); //
+  // const [personalSchedules, setPersonalSchedules] = useState([]); //
 
   const [level, setLevel] = useState(localLevel || "U");
 

--- a/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
@@ -47,21 +47,9 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
     params: {},
   });
 
-  // const getObjectToAxiosParams2 = () => ({ //
-  //   url: "/api/personalschedules/all",
-  //   method: "GET",
-  //   params: {},
-  // });
-
   const onSuccess = (listSubjects) => {
     setSubjects(listSubjects);
   };
-
-  // const onSuccess2 = (listPersonalSchedules) => { //
-  //   setPersonalSchedules(listPersonalSchedules);
-  // };
-
-
 
   const getMutation = useBackendMutation(
     getObjectToAxiosParams,
@@ -70,16 +58,8 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
     []
   );
 
-  // const getMutation2 = useBackendMutation( //
-  //   getObjectToAxiosParams2,
-  //   { onSuccess2 },
-  //   // Stryker disable next-line all : hard to set up test for caching
-  //   []
-  // );
-
   useEffect(() => {
     getMutation.mutate();
-    // getMutation2.mutate(); //
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -94,7 +74,7 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
 
   const handleSubmit = (event) => {
     event.preventDefault();
-    fetchJSON(event, { quarter, subject, level, personalSchedule });
+    fetchJSON(event, { quarter, subject, level });
   };
 
   // Stryker disable all : Stryker is testing by changing the padding to 0. But this is simply a visual optimization as it makes it look better

--- a/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
@@ -7,9 +7,8 @@ import { quarterRange } from "main/utils/quarterUtilities";
 import { useSystemInfo } from "main/utils/systemInfo";
 import SingleQuarterDropdown from "../Quarters/SingleQuarterDropdown";
 import SingleSubjectDropdown from "../Subjects/SingleSubjectDropdown";
-import SinglePersonalScheduleDropdown from "../PersonalSchedules/SinglePersonalScheduleDropdown"; //
 import SingleLevelDropdown from "../Levels/SingleLevelDropdown";
-import { useBackendMutation, useBackend } from "main/utils/useBackend";
+import { useBackendMutation } from "main/utils/useBackend";
 
 const BasicCourseSearchForm = ({ fetchJSON }) => {
 
@@ -22,18 +21,8 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
 
   const quarters = quarterRange(startQtr, endQtr);
 
-  const { data: personalSchedules, error: _error, status: _status } =
-  useBackend(
-      // Stryker disable next-line all : don't test internal caching of React Query
-      ["/api/personalschedules/all"],
-      { method: "GET", url: "/api/personalschedules/all" },
-      []
-  );
-
-
   // Stryker disable all : not sure how to test/mock local storage
   const localSubject = localStorage.getItem("BasicSearch.Subject");
-  const localPersonalSchedule = localStorage.getItem("BasicSearch.PersonalSchedule"); //
   const localQuarter = localStorage.getItem("BasicSearch.Quarter");
   const localLevel = localStorage.getItem("BasicSearch.CourseLevel");
 
@@ -46,6 +35,8 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
   const onSuccess = (listSubjects) => {
     setSubjects(listSubjects);
   };
+
+
 
   const getMutation = useBackendMutation(
     getObjectToAxiosParams,
@@ -62,12 +53,11 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
   const [quarter, setQuarter] = useState(localQuarter || quarters[0].yyyyq);
   const [subject, setSubject] = useState(localSubject || {});
   const [subjects, setSubjects] = useState([]);
-  const [personalSchedule, setPersonalSchedule] = useState(localPersonalSchedule || {}); //
   const [level, setLevel] = useState(localLevel || "U");
 
   const handleSubmit = (event) => {
     event.preventDefault();
-    fetchJSON(event, { quarter, subject, level }); //add personalSchedule param?
+    fetchJSON(event, { quarter, subject, level });
   };
 
   // Stryker disable all : Stryker is testing by changing the padding to 0. But this is simply a visual optimization as it makes it look better
@@ -97,14 +87,6 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
               level={level}
               setLevel={setLevel}
               controlId={"BasicSearch.Level"}
-            />
-          </Col>
-          <Col md="auto">
-            <SinglePersonalScheduleDropdown
-              personalSchedules={personalSchedules}
-              personalSchedule={personalSchedule}
-              setPersonalSchedule={setPersonalSchedule}
-              controlId={"BasicSearch.PersonalSchedule"}
             />
           </Col>
         </Row>

--- a/frontend/src/main/components/PersonalSchedules/SinglePersonalScheduleDropdown.js
+++ b/frontend/src/main/components/PersonalSchedules/SinglePersonalScheduleDropdown.js
@@ -1,0 +1,60 @@
+import React, { useState } from 'react'
+import { Form } from 'react-bootstrap';
+
+// controlId is used to remember the value for localStorage,
+// and for the testId, so it should be unique to at least any
+// given page where the component is used.
+
+// quarter and setQuarter should be values returned
+// by a parent component's setState 
+
+// quarters is an array of objects in this format
+// [{ yyyyq :"20214", qyy: "F21"},
+//  { yyyyq :"20221", qyy: "W22"}, 
+//  { yyyyq :"20222", qyy: "S22"}] 
+
+function SinglePersonalScheduleDropdown({ personalSchedules, setPersonalSchedule, controlId, onChange = null, label = "Personal Schedule" }) {
+
+    const localSearchPersonalSchedule = localStorage.getItem(controlId);
+
+    const [personalScheduleState, setPersonalScheduleState] = useState(
+    // Stryker disable next-line all : not sure how to test/mock local storage
+    localSearchPersonalSchedule || personalSchedules[0].yyyyq
+    );
+
+    const handlePersonalScheduleOnChange = (event) => {
+        const selectedPersonalSchedule = event.target.value;
+        localStorage.setItem(controlId, selectedPersonalSchedule);
+        setPersonalScheduleState(selectedPersonalSchedule);
+        setPersonalSchedule(selectedPersonalSchedule);
+        if (onChange != null) {
+            onChange(event);
+        }
+    };
+
+    return (
+        <Form.Group controlId={controlId}>
+            <Form.Label>{label}</Form.Label>
+            <Form.Control
+                as="select"
+                value={personalScheduleState}
+                onChange={handlePersonalScheduleOnChange}
+            >
+                {personalSchedules.map(function (object, i) {
+                    const key=`${controlId}-option-${i}`;
+                    return (
+                        <option
+                            key={key}
+                            data-testid={key}
+                            value={object.yyyyq}
+                        >
+                            {object.qyy}
+                        </option>
+                    );
+                })}
+            </Form.Control>
+        </Form.Group>
+    );
+};
+
+export default SinglePersonalScheduleDropdown;

--- a/frontend/src/main/components/PersonalSchedules/SinglePersonalScheduleDropdown.js
+++ b/frontend/src/main/components/PersonalSchedules/SinglePersonalScheduleDropdown.js
@@ -1,60 +1,52 @@
-import React, { useState } from 'react'
-import { Form } from 'react-bootstrap';
+import { compareValues } from "main/utils/sortHelper";
+import React, { useState } from "react";
+import { Form } from "react-bootstrap";
 
-// controlId is used to remember the value for localStorage,
-// and for the testId, so it should be unique to at least any
-// given page where the component is used.
+const SinglePersonalScheduleDropdown = ({
+  personalSchedules,
+  personalSchedule,
+  setPersonalSchedule,
+  controlId,
+  onChange = null,
+  label = "Personal Schedule",
+}) => {
+  const localSearchPersonalSchedule = localStorage.getItem(controlId);
 
-// quarter and setQuarter should be values returned
-// by a parent component's setState 
-
-// quarters is an array of objects in this format
-// [{ yyyyq :"20214", qyy: "F21"},
-//  { yyyyq :"20221", qyy: "W22"}, 
-//  { yyyyq :"20222", qyy: "S22"}] 
-
-function SinglePersonalScheduleDropdown({ personalSchedules, setPersonalSchedule, controlId, onChange = null, label = "Personal Schedule" }) {
-
-    const localSearchPersonalSchedule = localStorage.getItem(controlId);
-
-    const [personalScheduleState, setPersonalScheduleState] = useState(
+  const [personalScheduleState, setPersonalScheduleState] = useState(
     // Stryker disable next-line all : not sure how to test/mock local storage
-    localSearchPersonalSchedule || personalSchedules[0].yyyyq
-    );
+    localSearchPersonalSchedule || personalSchedule
+  );
 
-    const handlePersonalScheduleOnChange = (event) => {
-        const selectedPersonalSchedule = event.target.value;
-        localStorage.setItem(controlId, selectedPersonalSchedule);
-        setPersonalScheduleState(selectedPersonalSchedule);
-        setPersonalSchedule(selectedPersonalSchedule);
-        if (onChange != null) {
-            onChange(event);
-        }
-    };
+  const handlePersonalScheduleOnChange = (event) => {
+    localStorage.setItem(controlId, event.target.value);
+    setPersonalScheduleState(event.target.value);
+    setPersonalSchedule(event.target.value);
+    if (onChange != null) {
+      onChange(event);
+    }
+  };
 
-    return (
-        <Form.Group controlId={controlId}>
-            <Form.Label>{label}</Form.Label>
-            <Form.Control
-                as="select"
-                value={personalScheduleState}
-                onChange={handlePersonalScheduleOnChange}
-            >
-                {personalSchedules.map(function (object, i) {
-                    const key=`${controlId}-option-${i}`;
-                    return (
-                        <option
-                            key={key}
-                            data-testid={key}
-                            value={object.yyyyq}
-                        >
-                            {object.qyy}
-                        </option>
-                    );
-                })}
-            </Form.Control>
-        </Form.Group>
-    );
+  personalSchedules.sort(compareValues("id"));
+
+  return (
+    <Form.Group controlId={controlId}>
+      <Form.Label>{label}</Form.Label>
+      <Form.Control
+        as="select"
+        value={personalScheduleState}
+        onChange={handlePersonalScheduleOnChange}
+      >
+        {personalSchedules.map(function (object, i) {
+          const key = `${controlId}-option-${i}`;
+          return (
+            <option key={key} data-testid={key} value={object.id}>
+              {object.id} - {object.name}
+            </option>
+          );
+        })}
+      </Form.Control>
+    </Form.Group>
+  );
 };
 
 export default SinglePersonalScheduleDropdown;

--- a/frontend/src/main/components/PersonalSchedules/SinglePersonalScheduleDropdown.js
+++ b/frontend/src/main/components/PersonalSchedules/SinglePersonalScheduleDropdown.js
@@ -1,4 +1,3 @@
-import { compareValues } from "main/utils/sortHelper";
 import { yyyyqToQyy } from "main/utils/quarterUtilities";
 import React, { useState } from "react";
 import { Form } from "react-bootstrap";
@@ -26,8 +25,6 @@ const SinglePersonalScheduleDropdown = ({
       onChange(event);
     }
   };
-
-  personalSchedules.sort(compareValues("id"));
 
   return (
     <Form.Group controlId={controlId}>

--- a/frontend/src/main/components/PersonalSchedules/SinglePersonalScheduleDropdown.js
+++ b/frontend/src/main/components/PersonalSchedules/SinglePersonalScheduleDropdown.js
@@ -1,4 +1,5 @@
 import { compareValues } from "main/utils/sortHelper";
+import { yyyyqToQyy } from "main/utils/quarterUtilities";
 import React, { useState } from "react";
 import { Form } from "react-bootstrap";
 
@@ -40,7 +41,7 @@ const SinglePersonalScheduleDropdown = ({
           const key = `${controlId}-option-${i}`;
           return (
             <option key={key} data-testid={key} value={object.id}>
-              {object.id} - {object.name}
+              {object.id} - {yyyyqToQyy(object.quarter)} - {object.name}
             </option>
           );
         })}

--- a/frontend/src/stories/components/PersonalSchedules/SinglePersonalScheduleDropdown.stories.js
+++ b/frontend/src/stories/components/PersonalSchedules/SinglePersonalScheduleDropdown.stories.js
@@ -1,0 +1,33 @@
+import React, { useState } from 'react';
+
+import SinglePersonalScheduleDropdown from "main/components/PersonalSchedules/SinglePersonalScheduleDropdown";
+import { personalSchedulesFixtures } from "fixtures/personalSchedulesFixtures";
+
+export default {
+    title: 'components/PersonalSchedules/SinglePersonalScheduleDropdown',
+    component: SinglePersonalScheduleDropdown
+};
+
+const Template = (args) => {
+    const [personalSchedules, setPersonalSchedule] = useState(args.personalSchedules[0]);
+
+    return (
+        < SinglePersonalScheduleDropdown 
+        personalSchedules={personalSchedules} 
+        setPersonalSchedule={setPersonalSchedule} 
+        controlId={"SampleControlId"}
+        label={"Personal Schedule"} 
+        {...args} />
+    )
+};
+
+export const OnePersonalSchedule = Template.bind({});
+OnePersonalSchedule.args = {
+    personalSchedules: personalSchedulesFixtures.onePersonalSchedule
+};
+
+export const ThreePersonalSchedules = Template.bind({});
+ThreePersonalSchedules.args = {
+    personalSchedules: personalSchedulesFixtures.threePersonalSchedules
+};
+

--- a/frontend/src/stories/components/PersonalSchedules/SinglePersonalScheduleDropdown.stories.js
+++ b/frontend/src/stories/components/PersonalSchedules/SinglePersonalScheduleDropdown.stories.js
@@ -23,7 +23,7 @@ const Template = (args) => {
 
 export const OnePersonalSchedule = Template.bind({});
 OnePersonalSchedule.args = {
-    personalSchedules: personalSchedulesFixtures.onePersonalSchedule
+    personalSchedules: personalSchedulesFixtures.onePersonalScheduleArray
 };
 
 export const ThreePersonalSchedules = Template.bind({});

--- a/frontend/src/tests/components/PersonalSchedules/SinglePersonalScheduleDropdown.test.js
+++ b/frontend/src/tests/components/PersonalSchedules/SinglePersonalScheduleDropdown.test.js
@@ -40,7 +40,7 @@ describe("SinglePersonalScheduleDropdown tests", () => {
         personalSchedules={personalSchedulesFixtures.onePersonalScheduleArray}
         personalSchedule={personalSchedulesFixtures.onePersonalScheduleArray}
         setPersonalSchedule={setPersonalSchedule}
-        controlId="ssd1"
+        controlId="psd1"
       />
     );
   });
@@ -51,7 +51,7 @@ describe("SinglePersonalScheduleDropdown tests", () => {
         personalSchedules={personalSchedulesFixtures.threePersonalSchedules}
         personalSchedule={personalSchedule}
         setPersonalSchedule={setPersonalSchedule}
-        controlId="ssd1"
+        controlId="psd1"
       />
     );
   });
@@ -62,7 +62,7 @@ describe("SinglePersonalScheduleDropdown tests", () => {
         personalSchedules={personalSchedulesFixtures.threePersonalSchedules}
         personalSchedule={personalSchedule}
         setPersonalSchedule={setPersonalSchedule}
-        controlId="ssd1"
+        controlId="psd1"
       />
     );
     
@@ -80,7 +80,7 @@ describe("SinglePersonalScheduleDropdown tests", () => {
         personalSchedules={personalSchedulesFixtures.threePersonalSchedules}
         personalSchedule={personalSchedule}
         setPersonalSchedule={setPersonalSchedule}
-        controlId="ssd1"
+        controlId="psd1"
         onChange={onChange}
       />
     );
@@ -103,7 +103,7 @@ describe("SinglePersonalScheduleDropdown tests", () => {
         personalSchedules={personalSchedulesFixtures.threePersonalSchedules}
         personalSchedule={personalSchedule}
         setPersonalSchedule={setPersonalSchedule}
-        controlId="ssd1"
+        controlId="psd1"
       />
     );
     
@@ -116,11 +116,11 @@ describe("SinglePersonalScheduleDropdown tests", () => {
         personalSchedules={personalSchedulesFixtures.threePersonalSchedules}
         personalSchedule={personalSchedule}
         setPersonalSchedule={setPersonalSchedule}
-        controlId="ssd1"
+        controlId="psd1"
       />
     );
 
-    const expectedKey = "ssd1-option-0";
+    const expectedKey = "psd1-option-0";
     await waitFor(() => expect(screen.getByTestId(expectedKey).toBeInTheDocument));
   });
 
@@ -136,7 +136,7 @@ describe("SinglePersonalScheduleDropdown tests", () => {
         personalSchedules={personalSchedulesFixtures.threePersonalSchedules}
         personalSchedule={personalSchedule}
         setPersonalSchedule={setPersonalSchedule}
-        controlId="ssd1"
+        controlId="psd1"
       />
     );
 
@@ -155,7 +155,7 @@ describe("SinglePersonalScheduleDropdown tests", () => {
         personalSchedules={personalSchedulesFixtures.threePersonalSchedules}
         personalSchedule={personalSchedule}
         setPersonalSchedule={setPersonalSchedule}
-        controlId="ssd1"
+        controlId="psd1"
       />
     );
 
@@ -170,11 +170,11 @@ describe("SinglePersonalScheduleDropdown tests", () => {
         personalSchedules={[]}
         personalSchedule={personalSchedule}
         setPersonalSchedule={setPersonalSchedule}
-        controlId="ssd1"
+        controlId="psd1"
       />
     );
 
-    const expectedKey = "ssd1";
+    const expectedKey = "psd1";
     expect(screen.queryByTestId(expectedKey)).toBeNull();
   });
 });

--- a/frontend/src/tests/components/PersonalSchedules/SinglePersonalScheduleDropdown.test.js
+++ b/frontend/src/tests/components/PersonalSchedules/SinglePersonalScheduleDropdown.test.js
@@ -1,0 +1,180 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom/extend-expect";
+import { useState } from "react";
+
+import SinglePersonalScheduleDropdown from "main/components/PersonalSchedules/SinglePersonalScheduleDropdown";
+import { personalSchedulesFixtures } from "fixtures/personalSchedulesFixtures";
+
+jest.mock("react", () => ({
+  ...jest.requireActual("react"),
+  useState: jest.fn(),
+  compareValues: jest.fn(),
+}));
+
+describe("SinglePersonalScheduleDropdown tests", () => {
+
+  beforeEach(() => {
+    jest.spyOn(console, 'error')
+    console.error.mockImplementation(() => null);
+  });
+
+  beforeEach(() => {
+    useState.mockImplementation(jest.requireActual("react").useState);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    console.error.mockRestore();
+ })
+
+  const personalSchedule = jest.fn();
+  const setPersonalSchedule = jest.fn();
+
+  test("renders without crashing on one personalSchedule", () => {
+    render(
+      <SinglePersonalScheduleDropdown
+        personalSchedules={personalSchedulesFixtures.onePersonalScheduleArray}
+        personalSchedule={personalSchedulesFixtures.onePersonalScheduleArray}
+        setPersonalSchedule={setPersonalSchedule}
+        controlId="ssd1"
+      />
+    );
+  });
+
+  test("renders without crashing on three personalSchedules", () => {
+    render(
+      <SinglePersonalScheduleDropdown
+        personalSchedules={personalSchedulesFixtures.threePersonalSchedules}
+        personalSchedule={personalSchedule}
+        setPersonalSchedule={setPersonalSchedule}
+        controlId="ssd1"
+      />
+    );
+  });
+
+  test("when I select an object, the value changes", async () => {
+    render(
+      <SinglePersonalScheduleDropdown
+        personalSchedules={personalSchedulesFixtures.threePersonalSchedules}
+        personalSchedule={personalSchedule}
+        setPersonalSchedule={setPersonalSchedule}
+        controlId="ssd1"
+      />
+    );
+    
+    expect(await screen.findByLabelText("Personal Schedule")).toBeInTheDocument();
+
+    const selectPersonalSchedule = screen.getByLabelText("Personal Schedule");
+    userEvent.selectOptions(selectPersonalSchedule, "3");
+    expect(setPersonalSchedule).toBeCalledWith("3");
+  });
+
+  test("if I pass a non-null onChange, it gets called when the value changes", async () => {
+    const onChange = jest.fn();
+    render(
+      <SinglePersonalScheduleDropdown
+        personalSchedules={personalSchedulesFixtures.threePersonalSchedules}
+        personalSchedule={personalSchedule}
+        setPersonalSchedule={setPersonalSchedule}
+        controlId="ssd1"
+        onChange={onChange}
+      />
+    );
+    
+    expect(await screen.findByLabelText("Personal Schedule")).toBeInTheDocument();
+
+    const selectPersonalSchedule = screen.getByLabelText("Personal Schedule");
+    userEvent.selectOptions(selectPersonalSchedule, "2");
+    await waitFor(() => expect(setPersonalSchedule).toBeCalledWith("2"));
+    await waitFor(() => expect(onChange).toBeCalledTimes(1));
+
+    // x.mock.calls[0][0] is the first argument of the first call to the jest.fn() mock x
+    const event = onChange.mock.calls[0][0];
+    expect(event.target.value).toBe("2");
+  });
+
+  test("default label is Personal Schedule", async () => {
+    render(
+      <SinglePersonalScheduleDropdown
+        personalSchedules={personalSchedulesFixtures.threePersonalSchedules}
+        personalSchedule={personalSchedule}
+        setPersonalSchedule={setPersonalSchedule}
+        controlId="ssd1"
+      />
+    );
+    
+    expect(await screen.findByLabelText("Personal Schedule")).toBeInTheDocument();
+  });
+
+  test("keys / testids are set correctly on options", async () => {
+    render(
+      <SinglePersonalScheduleDropdown
+        personalSchedules={personalSchedulesFixtures.threePersonalSchedules}
+        personalSchedule={personalSchedule}
+        setPersonalSchedule={setPersonalSchedule}
+        controlId="ssd1"
+      />
+    );
+
+    const expectedKey = "ssd1-option-0";
+    await waitFor(() => expect(screen.getByTestId(expectedKey).toBeInTheDocument));
+  });
+
+  test("when localstorage has a value, it is passed to useState", async () => {
+    const getItemSpy = jest.spyOn(Storage.prototype, "getItem");
+    getItemSpy.mockImplementation(() => "3");
+
+    const setPersonalScheduleStateSpy = jest.fn();
+    useState.mockImplementation((x) => [x, setPersonalScheduleStateSpy]);
+
+    render(
+      <SinglePersonalScheduleDropdown
+        personalSchedules={personalSchedulesFixtures.threePersonalSchedules}
+        personalSchedule={personalSchedule}
+        setPersonalSchedule={setPersonalSchedule}
+        controlId="ssd1"
+      />
+    );
+
+    await waitFor(() => expect(useState).toBeCalledWith("3"));
+  });
+
+  test("when localstorage has no value, first element of personalSchedule list is passed to useState", async () => {
+    const getItemSpy = jest.spyOn(Storage.prototype, "getItem");
+    getItemSpy.mockImplementation(() => null);
+
+    const setPersonalScheduleStateSpy = jest.fn();
+    useState.mockImplementation((x) => [x, setPersonalScheduleStateSpy]);
+
+    render(
+      <SinglePersonalScheduleDropdown
+        personalSchedules={personalSchedulesFixtures.threePersonalSchedules}
+        personalSchedule={personalSchedule}
+        setPersonalSchedule={setPersonalSchedule}
+        controlId="ssd1"
+      />
+    );
+
+    await waitFor(() =>
+      expect(useState).toBeCalledWith(expect.objectContaining({}))
+    );
+  });
+
+  test("When no personalSchedules, dropdown is blank", async () => {
+    render(
+      <SinglePersonalScheduleDropdown
+        personalSchedules={[]}
+        personalSchedule={personalSchedule}
+        setPersonalSchedule={setPersonalSchedule}
+        controlId="ssd1"
+      />
+    );
+
+    const expectedKey = "ssd1";
+    expect(screen.queryByTestId(expectedKey)).toBeNull();
+  });
+});


### PR DESCRIPTION
Created a Personal Schedule dropdown list that shows all personal schedules in the format "id - QYY - name". Personal Schedules can be selected from this dropdown list and the state of the form should reflect the Personal Schedule selected. All frontend tests and mutation tests are passing on local machines. 

Storybook Link: https://ucsb-cs156-f22.github.io/f22-7pm-courses-docs-qa/storybook-qa/PersonalScheduleDropdown/?path=/docs/components-personalschedules-singlepersonalscheduledropdown--one-personal-schedule

Resolves  #3 