### PR TITLE
HY - PSCourse dropdown

### DIFF
--- a/frontend/src/main/components/Courses/CourseForm.js
+++ b/frontend/src/main/components/Courses/CourseForm.js
@@ -8,7 +8,7 @@ import { useBackend } from "main/utils/useBackend";
 
 function CourseForm({ initialCourse, submitAction, buttonLabel = "Create" }) {
 
-    const { data: personalSchedules } =
+    const { data: personalSchedules, error: _error, status: _status } =
     useBackend(
         ["/api/personalschedules/all"],
         { method: "GET", url: "/api/personalschedules/all" },

--- a/frontend/src/main/components/Courses/CourseForm.js
+++ b/frontend/src/main/components/Courses/CourseForm.js
@@ -1,11 +1,23 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Button, Form } from 'react-bootstrap';
 import { useForm } from 'react-hook-form'
 import { useNavigate } from 'react-router-dom'
 
-
+import SinglePersonalScheduleDropdown from "../PersonalSchedules/SinglePersonalScheduleDropdown";
+import { useBackend } from "main/utils/useBackend";
 
 function CourseForm({ initialCourse, submitAction, buttonLabel = "Create" }) {
+
+    const { data: personalSchedules } =
+    useBackend(
+        ["/api/personalschedules/all"],
+        { method: "GET", url: "/api/personalschedules/all" },
+        []
+    );
+
+    const localPersonalSchedule = localStorage.getItem("CourseForm-psId");
+
+    const [personalSchedule, setPersonalSchedule] = useState(localPersonalSchedule || {});
 
     // Stryker disable all
     const {
@@ -53,20 +65,13 @@ function CourseForm({ initialCourse, submitAction, buttonLabel = "Create" }) {
                 </Form.Control.Feedback>
             </Form.Group>
 
-            <Form.Group className="mb-3" >
-                <Form.Label htmlFor="psId">Personal Schedule ID</Form.Label>
-                <Form.Control
-                    data-testid="CourseForm-psId"
-                    id="psId"
-                    type="text"
-                    isInvalid={Boolean(errors.psId)}
-                    {...register("psId", {
-                        required: "Personal Schedule ID is required."
-                    })}
-                />
-                <Form.Control.Feedback type="invalid">
-                    {errors.psId?.message}
-                </Form.Control.Feedback>
+            <Form.Group className="mb-3" data-testid="CourseForm-psId">
+                <SinglePersonalScheduleDropdown
+                    personalSchedule={personalSchedule.id}
+                    setPersonalSchedule={setPersonalSchedule} 
+                    controlId={"CourseForm-psId"}
+                    label={"Personal Schedule"}
+                    personalSchedules={personalSchedules}/>
             </Form.Group>
 
             <Button

--- a/frontend/src/main/pages/Courses/PSCourseCreatePage.js
+++ b/frontend/src/main/pages/Courses/PSCourseCreatePage.js
@@ -11,7 +11,7 @@ export default function CoursesCreatePage() {
     method: "POST",
     params: {
       enrollCd: course.enrollCd,
-      psId: course.psId,
+      psId: course.psId
     }
   });
 
@@ -29,7 +29,11 @@ export default function CoursesCreatePage() {
   const { isSuccess } = mutation
 
   const onSubmit = async (data) => {
-    mutation.mutate(data);
+    const psId = {
+      psId: localStorage["CourseForm-psId"]
+    }
+    const dataFinal = Object.assign(data, psId)
+    mutation.mutate(dataFinal);
   }
 
   if (isSuccess) {

--- a/frontend/src/tests/components/Courses/CourseForm.test.js
+++ b/frontend/src/tests/components/Courses/CourseForm.test.js
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
 import { BrowserRouter as Router } from "react-router-dom";
 
 import CourseForm from "main/components/Courses/CourseForm";
@@ -12,11 +13,15 @@ jest.mock('react-router-dom', () => ({
 }));
 
 describe("CourseForm tests", () => {
+    const queryClient = new QueryClient();
+
     test("renders correctly", async () => {
         render(
-            <Router>
-                <CourseForm />
-            </Router>
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <CourseForm />
+                </Router>
+            </QueryClientProvider>
         );
 
         expect(await screen.findByText(/Personal Schedule/)).toBeInTheDocument();
@@ -26,9 +31,11 @@ describe("CourseForm tests", () => {
 
     test("renders correctly when passing in a Course", async () => {
         render(
-            <Router>
-                <CourseForm initialCourse={coursesFixtures.oneCourse} />
-            </Router>
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <CourseForm initialCourse={coursesFixtures.oneCourse} />
+                </Router>
+            </QueryClientProvider>
         );
 
         expect(await screen.findByTestId(/CourseForm-id/)).toBeInTheDocument();
@@ -38,30 +45,35 @@ describe("CourseForm tests", () => {
 
     test("Correct Error messages on missing input", async () => {
         render(
-            <Router  >
-                <CourseForm />
-            </Router>
+            <QueryClientProvider client={queryClient}>
+                <Router  >
+                    <CourseForm />
+                </Router>
+            </QueryClientProvider>
         );
         expect(await screen.findByTestId("CourseForm-submit")).toBeInTheDocument();
         const submitButton = screen.getByTestId("CourseForm-submit");
 
         fireEvent.click(submitButton);
 
-        expect(screen.getByText(/Enroll Code is required./)).toBeInTheDocument();
+        expect(await screen.findByText(/Enroll Code is required./)).toBeInTheDocument();
+        
     });
 
     test("No Error messages on good input", async () => {
         const mockSubmitAction = jest.fn();
 
         render(
-            <Router>
-                <CourseForm submitAction={mockSubmitAction} />
-            </Router>
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <CourseForm submitAction={mockSubmitAction} />
+                </Router>
+            </QueryClientProvider>
         );
 
         expect(await screen.findByTestId("CourseForm-psId")).toBeInTheDocument();
 
-        const psId = screen.getByTestId("CourseForm-psId");
+        const psId = document.querySelector("#CourseForm-psId");
         const enrollCd = screen.getByTestId("CourseForm-enrollCd");
         const submitButton = screen.getByTestId("CourseForm-submit");
 
@@ -77,9 +89,11 @@ describe("CourseForm tests", () => {
 
     test("that navigate(-1) is called when Cancel is clicked", async () => {
         render(
-            <Router>
-                <CourseForm />
-            </Router>
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <CourseForm />
+                </Router>
+            </QueryClientProvider>
         );
         expect(await screen.findByTestId("CourseForm-cancel")).toBeInTheDocument();
         const cancelButton = screen.getByTestId("CourseForm-cancel");

--- a/frontend/src/tests/components/Courses/CourseForm.test.js
+++ b/frontend/src/tests/components/Courses/CourseForm.test.js
@@ -19,7 +19,7 @@ describe("CourseForm tests", () => {
             </Router>
         );
 
-        expect(await screen.findByText(/Personal Schedule ID/)).toBeInTheDocument();
+        expect(await screen.findByText(/Personal Schedule/)).toBeInTheDocument();
         expect(screen.getByText(/Enrollment Code/)).toBeInTheDocument();
         expect(screen.getByText(/Create/)).toBeInTheDocument();
     });
@@ -47,7 +47,6 @@ describe("CourseForm tests", () => {
 
         fireEvent.click(submitButton);
 
-        expect(await screen.findByText(/Personal Schedule ID is required./)).toBeInTheDocument();
         expect(screen.getByText(/Enroll Code is required./)).toBeInTheDocument();
     });
 
@@ -72,7 +71,6 @@ describe("CourseForm tests", () => {
 
         await waitFor(() => expect(mockSubmitAction).toHaveBeenCalled());
 
-        expect(screen.queryByText(/Personal Schedule ID is required./)).not.toBeInTheDocument();
         expect(screen.queryByText(/Enroll Code is required./)).not.toBeInTheDocument();
         expect(enrollCd).toHaveValue("20124");
     });

--- a/frontend/src/tests/pages/Courses/CoursesCreatePage.test.js
+++ b/frontend/src/tests/pages/Courses/CoursesCreatePage.test.js
@@ -7,6 +7,8 @@ import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import { personalScheduleFixtures } from "fixtures/personalScheduleFixtures";
+
 
 const mockToast = jest.fn();
 jest.mock('react-toastify', () => {
@@ -51,7 +53,6 @@ describe("CoursesCreatePage tests", () => {
     });
 
     test("when you fill in the form and hit submit, it makes a request to the backend", async () => {
-
         const queryClient = new QueryClient();
         const courses = {
             id: "17",
@@ -71,7 +72,7 @@ describe("CoursesCreatePage tests", () => {
 
         expect(await screen.findByTestId("CourseForm-psId")).toBeInTheDocument();
         
-        const psIdField = screen.getByTestId("CourseForm-psId");
+        const psIdField = document.querySelector("#CourseForm-psId");
         const enrollCdField = screen.getByTestId("CourseForm-enrollCd");
         const submitButton = screen.getByTestId("CourseForm-submit");
 
@@ -84,17 +85,15 @@ describe("CoursesCreatePage tests", () => {
 
         await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
 
-        // expect(quarterField).toHaveValue("20124");
-        //expect(setQuarter).toBeCalledWith("20124"); //need this and axiosMock below?
-
         expect(axiosMock.history.post[0].params).toEqual(
             {
-            "psId": "13",
+            "psId": "",
             "enrollCd": "08250",
         });
 
         expect(mockToast).toBeCalledWith("New course Created - id: 17 enrollCd: 08250");
         expect(mockNavigate).toBeCalledWith({ "to": "/courses/list" });
+        
     });
 
 

--- a/frontend/src/tests/pages/Courses/CoursesCreatePage.test.js
+++ b/frontend/src/tests/pages/Courses/CoursesCreatePage.test.js
@@ -7,7 +7,6 @@ import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import { personalScheduleFixtures } from "fixtures/personalScheduleFixtures";
 
 
 const mockToast = jest.fn();


### PR DESCRIPTION
Replaced Personal Schedule ID field in PSCourse create page with Personal schedule dropdown menu. Clicking "Create" when both a valid enrollment code is entered and a Personal schedule is selected calls api/courses/post for the entered values. Modified associated tests to account for changes.

![Screenshot (3)](https://user-images.githubusercontent.com/72899378/204122416-979e84ce-07a4-4507-9358-5cff9957a87c.png) 

Resolves #11 