### PR TITLE
EE & MN - PersonalSectionsTable component + Storybook

### DIFF
--- a/frontend/src/fixtures/personalSectionsFixtures.js
+++ b/frontend/src/fixtures/personalSectionsFixtures.js
@@ -30,10 +30,10 @@ export const oneSection = [
           "timeLocations": [
             {
               "beginTime": "15:30",
-              "building": "string",
+              "building": "HFH",
               "days": "M W    ",
               "endTime": "16:45",
-              "room": "string",
+              "room": "1104",
               "roomCapacity": "string"
             }
           ]

--- a/frontend/src/fixtures/personalSectionsFixtures.js
+++ b/frontend/src/fixtures/personalSectionsFixtures.js
@@ -58,4 +58,482 @@ export const oneSection = [
       "quarter": "string",
       "title": "COMP ENGR SEMINAR"
     }
-  ]
+]
+
+export const threeSections = [
+  {
+    "classSections": [
+      {
+        "classClosed": "string",
+        "concurrentCourses": [
+          "string"
+        ],
+        "courseCancelled": "string",
+        "departmentApprovalRequired": true,
+        "enrollCode": "12591",
+        "enrolledTotal": 78,
+        "gradingOptionCode": "string",
+        "instructorApprovalRequired": true,
+        "instructors": [
+          {
+            "functionCode": "string",
+            "instructor": "HESPANHA J P"
+          }
+        ],
+        "maxEnroll": 120,
+        "restrictionLevel": "string",
+        "restrictionMajor": "string",
+        "restrictionMajorPass": "string",
+        "restrictionMinor": "string",
+        "restrictionMinorPass": "string",
+        "secondaryStatus": "string",
+        "section": "0100",
+        "session": "string",
+        "timeLocations": [
+          {
+            "beginTime": "12:30",
+            "building": "PHELP",
+            "days": "M    ",
+            "endTime": "13:45",
+            "room": "1260",
+            "roomCapacity": "string"
+          }
+        ]
+      }
+    ],
+    "courseId": "ECE       5  -1",
+    "description": "string",
+    "finalExam": {
+      "beginTime": "string",
+      "comments": "string",
+      "endTime": "string",
+      "examDate": "string",
+      "examDay": "string",
+      "hasFinals": true
+    },
+    "generalEducation": [
+      {
+        "geCode": "string",
+        "geCollege": "string"
+      }
+    ],
+    "quarter": "string",
+    "title": "INTRO TO ECE"
+  },
+  {
+    "classSections": [
+      {
+        "classClosed": "string",
+        "concurrentCourses": [
+          "string"
+        ],
+        "courseCancelled": "string",
+        "departmentApprovalRequired": true,
+        "enrollCode": "86918",
+        "enrolledTotal": 150,
+        "gradingOptionCode": "string",
+        "instructorApprovalRequired": true,
+        "instructors": [
+          {
+            "functionCode": "string",
+            "instructor": "VIGODA E J"
+          }
+        ],
+        "maxEnroll": 150,
+        "restrictionLevel": "string",
+        "restrictionMajor": "string",
+        "restrictionMajorPass": "string",
+        "restrictionMinor": "string",
+        "restrictionMinorPass": "string",
+        "secondaryStatus": "string",
+        "section": "3829",
+        "session": "string",
+        "timeLocations": [
+          {
+            "beginTime": "17:00",
+            "building": "LSB",
+            "days": "T R    ",
+            "endTime": "18:15",
+            "room": "1001",
+            "roomCapacity": "string"
+          }
+        ]
+      }
+    ],
+    "courseId": "CMPSC       130B -1",
+    "description": "string",
+    "finalExam": {
+      "beginTime": "string",
+      "comments": "string",
+      "endTime": "string",
+      "examDate": "string",
+      "examDay": "string",
+      "hasFinals": true
+    },
+    "generalEducation": [
+      {
+        "geCode": "string",
+        "geCollege": "string"
+      }
+    ],
+    "quarter": "string",
+    "title": "DATA STRUCT ALG II"
+  },
+  {
+    "classSections": [
+      {
+        "classClosed": "string",
+        "concurrentCourses": [
+          "string"
+        ],
+        "courseCancelled": "string",
+        "departmentApprovalRequired": true,
+        "enrollCode": "48321",
+        "enrolledTotal": 118,
+        "gradingOptionCode": "string",
+        "instructorApprovalRequired": true,
+        "instructors": [
+          {
+            "functionCode": "string",
+            "instructor": "ISUKAPALLI Y"
+          }
+        ],
+        "maxEnroll": 120,
+        "restrictionLevel": "string",
+        "restrictionMajor": "string",
+        "restrictionMajorPass": "string",
+        "restrictionMinor": "string",
+        "restrictionMinorPass": "string",
+        "secondaryStatus": "string",
+        "section": "4180",
+        "session": "string",
+        "timeLocations": [
+          {
+            "beginTime": "15:30",
+            "building": "TD-W",
+            "days": "M W    ",
+            "endTime": "16:45",
+            "room": "2600",
+            "roomCapacity": "string"
+          }
+        ]
+      }
+    ],
+    "courseId": "ECE       153B -1",
+    "description": "string",
+    "finalExam": {
+      "beginTime": "string",
+      "comments": "string",
+      "endTime": "string",
+      "examDate": "string",
+      "examDay": "string",
+      "hasFinals": true
+    },
+    "generalEducation": [
+      {
+        "geCode": "string",
+        "geCollege": "string"
+      }
+    ],
+    "quarter": "string",
+    "title": "SNSR/PERPH INT DSGN"
+  }
+]
+
+export const fiveSections = [
+  {
+    "classSections": [
+      {
+        "classClosed": "string",
+        "concurrentCourses": [
+          "string"
+        ],
+        "courseCancelled": "string",
+        "departmentApprovalRequired": true,
+        "enrollCode": "12591",
+        "enrolledTotal": 78,
+        "gradingOptionCode": "string",
+        "instructorApprovalRequired": true,
+        "instructors": [
+          {
+            "functionCode": "string",
+            "instructor": "HESPANHA J P"
+          }
+        ],
+        "maxEnroll": 120,
+        "restrictionLevel": "string",
+        "restrictionMajor": "string",
+        "restrictionMajorPass": "string",
+        "restrictionMinor": "string",
+        "restrictionMinorPass": "string",
+        "secondaryStatus": "string",
+        "section": "0100",
+        "session": "string",
+        "timeLocations": [
+          {
+            "beginTime": "12:30",
+            "building": "PHELP",
+            "days": "M    ",
+            "endTime": "13:45",
+            "room": "1260",
+            "roomCapacity": "string"
+          }
+        ]
+      }
+    ],
+    "courseId": "ECE       5  -1",
+    "description": "string",
+    "finalExam": {
+      "beginTime": "string",
+      "comments": "string",
+      "endTime": "string",
+      "examDate": "string",
+      "examDay": "string",
+      "hasFinals": true
+    },
+    "generalEducation": [
+      {
+        "geCode": "string",
+        "geCollege": "string"
+      }
+    ],
+    "quarter": "string",
+    "title": "INTRO TO ECE"
+  },
+  {
+    "classSections": [
+      {
+        "classClosed": "string",
+        "concurrentCourses": [
+          "string"
+        ],
+        "courseCancelled": "string",
+        "departmentApprovalRequired": true,
+        "enrollCode": "86918",
+        "enrolledTotal": 150,
+        "gradingOptionCode": "string",
+        "instructorApprovalRequired": true,
+        "instructors": [
+          {
+            "functionCode": "string",
+            "instructor": "VIGODA E J"
+          }
+        ],
+        "maxEnroll": 150,
+        "restrictionLevel": "string",
+        "restrictionMajor": "string",
+        "restrictionMajorPass": "string",
+        "restrictionMinor": "string",
+        "restrictionMinorPass": "string",
+        "secondaryStatus": "string",
+        "section": "3829",
+        "session": "string",
+        "timeLocations": [
+          {
+            "beginTime": "17:00",
+            "building": "LSB",
+            "days": "T R    ",
+            "endTime": "18:15",
+            "room": "1001",
+            "roomCapacity": "string"
+          }
+        ]
+      }
+    ],
+    "courseId": "CMPSC       130B -1",
+    "description": "string",
+    "finalExam": {
+      "beginTime": "string",
+      "comments": "string",
+      "endTime": "string",
+      "examDate": "string",
+      "examDay": "string",
+      "hasFinals": true
+    },
+    "generalEducation": [
+      {
+        "geCode": "string",
+        "geCollege": "string"
+      }
+    ],
+    "quarter": "string",
+    "title": "DATA STRUCT ALG II"
+  },
+  {
+    "classSections": [
+      {
+        "classClosed": "string",
+        "concurrentCourses": [
+          "string"
+        ],
+        "courseCancelled": "string",
+        "departmentApprovalRequired": true,
+        "enrollCode": "48321",
+        "enrolledTotal": 118,
+        "gradingOptionCode": "string",
+        "instructorApprovalRequired": true,
+        "instructors": [
+          {
+            "functionCode": "string",
+            "instructor": "ISUKAPALLI Y"
+          }
+        ],
+        "maxEnroll": 120,
+        "restrictionLevel": "string",
+        "restrictionMajor": "string",
+        "restrictionMajorPass": "string",
+        "restrictionMinor": "string",
+        "restrictionMinorPass": "string",
+        "secondaryStatus": "string",
+        "section": "4180",
+        "session": "string",
+        "timeLocations": [
+          {
+            "beginTime": "15:30",
+            "building": "TD-W",
+            "days": "M W    ",
+            "endTime": "16:45",
+            "room": "2600",
+            "roomCapacity": "string"
+          }
+        ]
+      }
+    ],
+    "courseId": "ECE       153B -1",
+    "description": "string",
+    "finalExam": {
+      "beginTime": "string",
+      "comments": "string",
+      "endTime": "string",
+      "examDate": "string",
+      "examDay": "string",
+      "hasFinals": true
+    },
+    "generalEducation": [
+      {
+        "geCode": "string",
+        "geCollege": "string"
+      }
+    ],
+    "quarter": "string",
+    "title": "SNSR/PERPH INT DSGN"
+  },
+  {
+    "classSections": [
+      {
+        "classClosed": "string",
+        "concurrentCourses": [
+          "string"
+        ],
+        "courseCancelled": "string",
+        "departmentApprovalRequired": true,
+        "enrollCode": "58941",
+        "enrolledTotal": 70,
+        "gradingOptionCode": "string",
+        "instructorApprovalRequired": true,
+        "instructors": [
+          {
+            "functionCode": "string",
+            "instructor": "HILLIS G A"
+          }
+        ],
+        "maxEnroll": 70,
+        "restrictionLevel": "string",
+        "restrictionMajor": "string",
+        "restrictionMajorPass": "string",
+        "restrictionMinor": "string",
+        "restrictionMinorPass": "string",
+        "secondaryStatus": "string",
+        "section": "6874",
+        "session": "string",
+        "timeLocations": [
+          {
+            "beginTime": "12:30",
+            "building": "HFH",
+            "days": "M W    ",
+            "endTime": "13:45",
+            "room": "1104",
+            "roomCapacity": "string"
+          }
+        ]
+      }
+    ],
+    "courseId": "EACS       5 -1",
+    "description": "string",
+    "finalExam": {
+      "beginTime": "string",
+      "comments": "string",
+      "endTime": "string",
+      "examDate": "string",
+      "examDay": "string",
+      "hasFinals": true
+    },
+    "generalEducation": [
+      {
+        "geCode": "string",
+        "geCollege": "string"
+      }
+    ],
+    "quarter": "string",
+    "title": "INTRO TO BUDDHISM"
+  },
+  {
+    "classSections": [
+      {
+        "classClosed": "string",
+        "concurrentCourses": [
+          "string"
+        ],
+        "courseCancelled": "string",
+        "departmentApprovalRequired": true,
+        "enrollCode": "07567",
+        "enrolledTotal": 138,
+        "gradingOptionCode": "string",
+        "instructorApprovalRequired": true,
+        "instructors": [
+          {
+            "functionCode": "string",
+            "instructor": "CONRAD P T"
+          }
+        ],
+        "maxEnroll": 150,
+        "restrictionLevel": "string",
+        "restrictionMajor": "string",
+        "restrictionMajorPass": "string",
+        "restrictionMinor": "string",
+        "restrictionMinorPass": "string",
+        "secondaryStatus": "string",
+        "section": "1298",
+        "session": "string",
+        "timeLocations": [
+          {
+            "beginTime": "14:00",
+            "building": "LSB",
+            "days": "M W    ",
+            "endTime": "15:15",
+            "room": "1001",
+            "roomCapacity": "string"
+          }
+        ]
+      }
+    ],
+    "courseId": "CMPSC       16 -1",
+    "description": "string",
+    "finalExam": {
+      "beginTime": "string",
+      "comments": "string",
+      "endTime": "string",
+      "examDate": "string",
+      "examDay": "string",
+      "hasFinals": true
+    },
+    "generalEducation": [
+      {
+        "geCode": "string",
+        "geCollege": "string"
+      }
+    ],
+    "quarter": "string",
+    "title": "PROBLEM SOLVING I"
+  }
+]

--- a/frontend/src/fixtures/personalSectionsFixtures.js
+++ b/frontend/src/fixtures/personalSectionsFixtures.js
@@ -1,0 +1,61 @@
+export const oneSection = [
+    {
+      "classSections": [
+        {
+          "classClosed": "string",
+          "concurrentCourses": [
+            "string"
+          ],
+          "courseCancelled": "string",
+          "departmentApprovalRequired": true,
+          "enrollCode": "12345",
+          "enrolledTotal": 83,
+          "gradingOptionCode": "string",
+          "instructorApprovalRequired": true,
+          "instructors": [
+            {
+              "functionCode": "string",
+              "instructor": "WANG L C"
+            }
+          ],
+          "maxEnroll": 100,
+          "restrictionLevel": "string",
+          "restrictionMajor": "string",
+          "restrictionMajorPass": "string",
+          "restrictionMinor": "string",
+          "restrictionMinorPass": "string",
+          "secondaryStatus": "string",
+          "section": "0100",
+          "session": "string",
+          "timeLocations": [
+            {
+              "beginTime": "15:30",
+              "building": "string",
+              "days": "M W    ",
+              "endTime": "16:45",
+              "room": "string",
+              "roomCapacity": "string"
+            }
+          ]
+        }
+      ],
+      "courseId": "ECE       1A -1",
+      "description": "string",
+      "finalExam": {
+        "beginTime": "string",
+        "comments": "string",
+        "endTime": "string",
+        "examDate": "string",
+        "examDay": "string",
+        "hasFinals": true
+      },
+      "generalEducation": [
+        {
+          "geCode": "string",
+          "geCollege": "string"
+        }
+      ],
+      "quarter": "string",
+      "title": "COMP ENGR SEMINAR"
+    }
+  ]

--- a/frontend/src/main/components/PersonalSections/PersonalSectionsTable.js
+++ b/frontend/src/main/components/PersonalSections/PersonalSectionsTable.js
@@ -13,15 +13,6 @@ export default function PersonalSectionsTable({ personalSections }) {
 
     const columns = [
         {
-            Header: 'Quarter',
-            accessor: (row) => yyyyqToQyy(row.courseInfo.quarter),
-            disableGroupBy: true,
-            id: 'quarter',
-
-            aggregate: getFirstVal,
-            Aggregated: ({ cell: { value } }) => `${value}`
-        },
-        {
             Header: 'Course ID',
             accessor: 'courseInfo.courseId',
 

--- a/frontend/src/main/components/PersonalSections/PersonalSectionsTable.js
+++ b/frontend/src/main/components/PersonalSections/PersonalSectionsTable.js
@@ -1,0 +1,108 @@
+import React from "react";
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+import SectionsTableBase from "main/components/SectionsTableBase";
+
+import { convertToFraction, formatDays, formatInstructors, formatLocation, formatTime, isSection } from "main/utils/sectionUtils.js";
+
+import { useBackendMutation } from "main/utils/useBackend";
+// import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/PersonalScheduleUtils"
+import { useNavigate } from "react-router-dom";
+import { yyyyqToQyy } from "main/utils/quarterUtilities.js";
+
+export default function PersonalSectionsTable({ personalSections }) {
+
+    const columns = [
+        {
+            Header: 'Quarter',
+            accessor: (row) => yyyyqToQyy(row.courseInfo.quarter),
+            disableGroupBy: true,
+            id: 'quarter',
+
+            aggregate: getFirstVal,
+            Aggregated: ({ cell: { value } }) => `${value}`
+        },
+        {
+            Header: 'Course ID',
+            accessor: 'courseInfo.courseId',
+
+            Cell: ({ cell: { value } }) => value.substring(0, value.length-2)
+        },
+        {
+            Header: 'Title',
+            accessor: 'courseInfo.title',
+            disableGroupBy: true,
+
+            aggregate: getFirstVal,
+            Aggregated: ({ cell: { value } }) => `${value}`
+        },
+        {
+            // Stryker disable next-line StringLiteral: this column is hidden, very hard to test
+            Header: 'Is Section?',
+            accessor: (row) => isSection(row.section.section),
+            // Stryker disable next-line StringLiteral: this column is hidden, very hard to test
+            id: 'isSection',
+        },
+        {
+            Header: 'Enrolled',
+            accessor: (row) => convertToFraction(row.section.enrolledTotal, row.section.maxEnroll),
+            disableGroupBy: true,
+            id: 'enrolled',
+
+            aggregate: getFirstVal,
+            Aggregated: ({ cell: { value } }) => `${value}`
+        },
+        {
+            Header: 'Location',
+            accessor: (row) => formatLocation(row.section.timeLocations),
+            disableGroupBy: true,
+            id: 'location',
+
+            aggregate: getFirstVal,
+            Aggregated: ({ cell: { value } }) => `${value}`
+        },
+        {
+            Header: 'Days',
+            accessor: (row) => formatDays(row.section.timeLocations),
+            disableGroupBy: true,
+            id: 'days',
+
+            aggregate: getFirstVal,
+            Aggregated: ({ cell: { value } }) => `${value}`
+        },
+        {
+            Header: 'Time',
+            accessor: (row) => formatTime(row.section.timeLocations),
+            disableGroupBy: true,
+            id: 'time',
+
+            aggregate: getFirstVal,
+            Aggregated: ({ cell: { value } }) => `${value}`
+        },
+        {
+            Header: 'Instructor',
+            accessor: (row) => formatInstructors(row.section.instructors),
+            disableGroupBy: true,
+            id: 'instructor',
+
+            aggregate: getFirstVal,
+            Aggregated: ({ cell: { value } }) => `${value}`
+        },        
+        {
+            Header: 'Enroll Code',
+            accessor: 'section.enrollCode', 
+            disableGroupBy: true,
+
+            aggregate: getFirstVal,
+            Aggregated: ({ cell: { value } }) => `${value}`
+        }
+    ];
+
+    const columnsToDisplay = columns;
+
+
+    return <SectionsTableBase
+        data={personalSections}
+        columns={columnsToDisplay}
+        testid={"PersonalScectionsTable"}
+    />;
+};

--- a/frontend/src/main/components/PersonalSections/PersonalSectionsTable.js
+++ b/frontend/src/main/components/PersonalSections/PersonalSectionsTable.js
@@ -4,9 +4,6 @@ import SectionsTableBase from "main/components/SectionsTableBase";
 import { convertToFraction, formatDays, formatInstructors, formatLocation, formatTime } from "main/utils/sectionUtils.js";
 
 
-// function getFirstVal(values){
-//     return values[0];
-// }
 
 export default function PersonalSectionsTable({ personalSections }) {
 
@@ -23,72 +20,47 @@ export default function PersonalSectionsTable({ personalSections }) {
             Header: 'Enroll Code',
             accessor: 'classSections[0].enrollCode', 
             disableGroupBy: true,
-
-            // aggregate: getFirstVal,
-            // Aggregated: ({ cell: { value } }) => `${value}`
         },
         {
             Header: 'Section',
             accessor: "classSections[0].section",
             disableGroupBy: true,
-
-
-            // aggregate: getFirstVal,
-            // Aggregated: ({ cell: { value } }) => `${value}`
         },
         {
             Header: 'Title',
             accessor: 'title',
-            disableGroupBy: true,
-
-            // aggregate: getFirstVal,
-            // Aggregated: ({ cell: { value } }) => `${value}`
+            disableGroupBy: true
         },
 
         {
             Header: 'Enrolled',
             accessor: (row) => convertToFraction(row.classSections[0].enrolledTotal, row.classSections[0].maxEnroll),
             disableGroupBy: true,
-            id: 'enrolled',
-
-            // aggregate: getFirstVal,
-            // Aggregated: ({ cell: { value } }) => `${value}`
+            id: 'enrolled'
         },
         {
             Header: 'Location',
             accessor: (row) => formatLocation(row.classSections[0].timeLocations),
             disableGroupBy: true,
-            id: 'location',
-
-            // aggregate: getFirstVal,
-            // Aggregated: ({ cell: { value } }) => `${value}`
+            id: 'location'
         },
         {
             Header: 'Days',
             accessor: (row) => formatDays(row.classSections[0].timeLocations),
             disableGroupBy: true,
-            id: 'days',
-
-            // aggregate: getFirstVal,
-            // Aggregated: ({ cell: { value } }) => `${value}`
+            id: 'days'
         },
         {
             Header: 'Time',
             accessor: (row) => formatTime(row.classSections[0].timeLocations),
             disableGroupBy: true,
-            id: 'time',
-
-            // aggregate: getFirstVal,
-            // Aggregated: ({ cell: { value } }) => `${value}`
+            id: 'time'
         },
         {
             Header: 'Instructor',
             accessor: (row) => formatInstructors(row.classSections[0].instructors),
             disableGroupBy: true,
-            id: 'instructor',
-
-            // aggregate: getFirstVal,
-            // Aggregated: ({ cell: { value } }) => `${value}`
+            id: 'instructor'
         }   
     ];
 

--- a/frontend/src/main/components/PersonalSections/PersonalSectionsTable.js
+++ b/frontend/src/main/components/PersonalSections/PersonalSectionsTable.js
@@ -4,12 +4,14 @@ import SectionsTableBase from "main/components/SectionsTableBase";
 import { convertToFraction, formatDays, formatInstructors, formatLocation, formatTime } from "main/utils/sectionUtils.js";
 
 
-function getFirstVal(values){
-    return values[0];
-}
+// function getFirstVal(values){
+//     return values[0];
+// }
 
 export default function PersonalSectionsTable({ personalSections }) {
 
+    // Stryker enable all 
+    // Stryker disable BooleanLiteral
     const columns = [
         {
             Header: 'Course ID',
@@ -22,8 +24,8 @@ export default function PersonalSectionsTable({ personalSections }) {
             accessor: 'classSections[0].enrollCode', 
             disableGroupBy: true,
 
-            aggregate: getFirstVal,
-            Aggregated: ({ cell: { value } }) => `${value}`
+            // aggregate: getFirstVal,
+            // Aggregated: ({ cell: { value } }) => `${value}`
         },
         {
             Header: 'Section',
@@ -31,16 +33,16 @@ export default function PersonalSectionsTable({ personalSections }) {
             disableGroupBy: true,
 
 
-            aggregate: getFirstVal,
-            Aggregated: ({ cell: { value } }) => `${value}`
+            // aggregate: getFirstVal,
+            // Aggregated: ({ cell: { value } }) => `${value}`
         },
         {
             Header: 'Title',
             accessor: 'title',
             disableGroupBy: true,
 
-            aggregate: getFirstVal,
-            Aggregated: ({ cell: { value } }) => `${value}`
+            // aggregate: getFirstVal,
+            // Aggregated: ({ cell: { value } }) => `${value}`
         },
 
         {
@@ -49,8 +51,8 @@ export default function PersonalSectionsTable({ personalSections }) {
             disableGroupBy: true,
             id: 'enrolled',
 
-            aggregate: getFirstVal,
-            Aggregated: ({ cell: { value } }) => `${value}`
+            // aggregate: getFirstVal,
+            // Aggregated: ({ cell: { value } }) => `${value}`
         },
         {
             Header: 'Location',
@@ -58,8 +60,8 @@ export default function PersonalSectionsTable({ personalSections }) {
             disableGroupBy: true,
             id: 'location',
 
-            aggregate: getFirstVal,
-            Aggregated: ({ cell: { value } }) => `${value}`
+            // aggregate: getFirstVal,
+            // Aggregated: ({ cell: { value } }) => `${value}`
         },
         {
             Header: 'Days',
@@ -67,8 +69,8 @@ export default function PersonalSectionsTable({ personalSections }) {
             disableGroupBy: true,
             id: 'days',
 
-            aggregate: getFirstVal,
-            Aggregated: ({ cell: { value } }) => `${value}`
+            // aggregate: getFirstVal,
+            // Aggregated: ({ cell: { value } }) => `${value}`
         },
         {
             Header: 'Time',
@@ -76,8 +78,8 @@ export default function PersonalSectionsTable({ personalSections }) {
             disableGroupBy: true,
             id: 'time',
 
-            aggregate: getFirstVal,
-            Aggregated: ({ cell: { value } }) => `${value}`
+            // aggregate: getFirstVal,
+            // Aggregated: ({ cell: { value } }) => `${value}`
         },
         {
             Header: 'Instructor',
@@ -85,8 +87,8 @@ export default function PersonalSectionsTable({ personalSections }) {
             disableGroupBy: true,
             id: 'instructor',
 
-            aggregate: getFirstVal,
-            Aggregated: ({ cell: { value } }) => `${value}`
+            // aggregate: getFirstVal,
+            // Aggregated: ({ cell: { value } }) => `${value}`
         }   
     ];
 

--- a/frontend/src/main/components/PersonalSections/PersonalSectionsTable.js
+++ b/frontend/src/main/components/PersonalSections/PersonalSectionsTable.js
@@ -24,7 +24,7 @@ export default function PersonalSectionsTable({ personalSections }) {
         },
         {
             Header: 'Enroll Code',
-            accessor: 'classSections.enrollCode', 
+            accessor: 'classSections[0].enrollCode', 
             disableGroupBy: true,
 
             aggregate: getFirstVal,
@@ -32,7 +32,7 @@ export default function PersonalSectionsTable({ personalSections }) {
         },
         {
             Header: 'Section',
-            accessor: "classSections.section",
+            accessor: "classSections[0].section",
             disableGroupBy: true,
 
 
@@ -50,7 +50,7 @@ export default function PersonalSectionsTable({ personalSections }) {
 
         {
             Header: 'Enrolled',
-            accessor: (row) => convertToFraction(row.classSections.enrolledTotal, row.classSections.maxEnroll),
+            accessor: (row) => convertToFraction(row.classSections[0].enrolledTotal, row.classSections[0].maxEnroll),
             disableGroupBy: true,
             id: 'enrolled',
 
@@ -59,7 +59,7 @@ export default function PersonalSectionsTable({ personalSections }) {
         },
         {
             Header: 'Location',
-            accessor: (row) => formatLocation(row.classSections.timeLocations),
+            accessor: (row) => formatLocation(row.classSections[0].timeLocations),
             disableGroupBy: true,
             id: 'location',
 
@@ -68,7 +68,7 @@ export default function PersonalSectionsTable({ personalSections }) {
         },
         {
             Header: 'Days',
-            accessor: (row) => formatDays(row.classSections.timeLocations),
+            accessor: (row) => formatDays(row.classSections[0].timeLocations),
             disableGroupBy: true,
             id: 'days',
 
@@ -77,7 +77,7 @@ export default function PersonalSectionsTable({ personalSections }) {
         },
         {
             Header: 'Time',
-            accessor: (row) => formatTime(row.classSections.timeLocations),
+            accessor: (row) => formatTime(row.classSections[0].timeLocations),
             disableGroupBy: true,
             id: 'time',
 
@@ -86,7 +86,7 @@ export default function PersonalSectionsTable({ personalSections }) {
         },
         {
             Header: 'Instructor',
-            accessor: (row) => formatInstructors(row.classSections.instructors),
+            accessor: (row) => formatInstructors(row.classSections[0].instructors),
             disableGroupBy: true,
             id: 'instructor',
 
@@ -101,6 +101,6 @@ export default function PersonalSectionsTable({ personalSections }) {
     return <SectionsTableBase
         data={personalSections}
         columns={columnsToDisplay}
-        testid={"PersonalScectionsTable"}
+        testid={"PersonalSectionsTable"}
     />;
 };

--- a/frontend/src/main/components/PersonalSections/PersonalSectionsTable.js
+++ b/frontend/src/main/components/PersonalSections/PersonalSectionsTable.js
@@ -1,13 +1,13 @@
 import React from "react";
-import OurTable, { ButtonColumn } from "main/components/OurTable";
+// import OurTable, { ButtonColumn } from "main/components/OurTable";
 import SectionsTableBase from "main/components/SectionsTableBase";
 
 import { convertToFraction, formatDays, formatInstructors, formatLocation, formatTime, isSection } from "main/utils/sectionUtils.js";
 
-import { useBackendMutation } from "main/utils/useBackend";
+// import { useBackendMutation } from "main/utils/useBackend";
 // import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/PersonalScheduleUtils"
-import { useNavigate } from "react-router-dom";
-import { yyyyqToQyy } from "main/utils/quarterUtilities.js";
+// import { useNavigate } from "react-router-dom";
+// import { yyyyqToQyy } from "main/utils/quarterUtilities.js";
 
 export default function PersonalSectionsTable({ personalSections }) {
 

--- a/frontend/src/main/components/PersonalSections/PersonalSectionsTable.js
+++ b/frontend/src/main/components/PersonalSections/PersonalSectionsTable.js
@@ -2,40 +2,55 @@ import React from "react";
 // import OurTable, { ButtonColumn } from "main/components/OurTable";
 import SectionsTableBase from "main/components/SectionsTableBase";
 
-import { convertToFraction, formatDays, formatInstructors, formatLocation, formatTime, isSection } from "main/utils/sectionUtils.js";
+import { convertToFraction, formatDays, formatInstructors, formatLocation, formatTime } from "main/utils/sectionUtils.js";
 
 // import { useBackendMutation } from "main/utils/useBackend";
 // import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/PersonalScheduleUtils"
 // import { useNavigate } from "react-router-dom";
 // import { yyyyqToQyy } from "main/utils/quarterUtilities.js";
 
+function getFirstVal(values){
+    return values[0];
+}
+
 export default function PersonalSectionsTable({ personalSections }) {
 
     const columns = [
         {
             Header: 'Course ID',
-            accessor: 'courseInfo.courseId',
+            accessor: 'courseId',
 
             Cell: ({ cell: { value } }) => value.substring(0, value.length-2)
         },
         {
-            Header: 'Title',
-            accessor: 'courseInfo.title',
+            Header: 'Enroll Code',
+            accessor: 'classSections.enrollCode', 
             disableGroupBy: true,
 
             aggregate: getFirstVal,
             Aggregated: ({ cell: { value } }) => `${value}`
         },
         {
-            // Stryker disable next-line StringLiteral: this column is hidden, very hard to test
-            Header: 'Is Section?',
-            accessor: (row) => isSection(row.section.section),
-            // Stryker disable next-line StringLiteral: this column is hidden, very hard to test
-            id: 'isSection',
+            Header: 'Section',
+            accessor: "classSections.section",
+            disableGroupBy: true,
+
+
+            aggregate: getFirstVal,
+            Aggregated: ({ cell: { value } }) => `${value}`
         },
         {
+            Header: 'Title',
+            accessor: 'title',
+            disableGroupBy: true,
+
+            aggregate: getFirstVal,
+            Aggregated: ({ cell: { value } }) => `${value}`
+        },
+
+        {
             Header: 'Enrolled',
-            accessor: (row) => convertToFraction(row.section.enrolledTotal, row.section.maxEnroll),
+            accessor: (row) => convertToFraction(row.classSections.enrolledTotal, row.classSections.maxEnroll),
             disableGroupBy: true,
             id: 'enrolled',
 
@@ -44,7 +59,7 @@ export default function PersonalSectionsTable({ personalSections }) {
         },
         {
             Header: 'Location',
-            accessor: (row) => formatLocation(row.section.timeLocations),
+            accessor: (row) => formatLocation(row.classSections.timeLocations),
             disableGroupBy: true,
             id: 'location',
 
@@ -53,7 +68,7 @@ export default function PersonalSectionsTable({ personalSections }) {
         },
         {
             Header: 'Days',
-            accessor: (row) => formatDays(row.section.timeLocations),
+            accessor: (row) => formatDays(row.classSections.timeLocations),
             disableGroupBy: true,
             id: 'days',
 
@@ -62,7 +77,7 @@ export default function PersonalSectionsTable({ personalSections }) {
         },
         {
             Header: 'Time',
-            accessor: (row) => formatTime(row.section.timeLocations),
+            accessor: (row) => formatTime(row.classSections.timeLocations),
             disableGroupBy: true,
             id: 'time',
 
@@ -71,21 +86,13 @@ export default function PersonalSectionsTable({ personalSections }) {
         },
         {
             Header: 'Instructor',
-            accessor: (row) => formatInstructors(row.section.instructors),
+            accessor: (row) => formatInstructors(row.classSections.instructors),
             disableGroupBy: true,
             id: 'instructor',
 
             aggregate: getFirstVal,
             Aggregated: ({ cell: { value } }) => `${value}`
-        },        
-        {
-            Header: 'Enroll Code',
-            accessor: 'section.enrollCode', 
-            disableGroupBy: true,
-
-            aggregate: getFirstVal,
-            Aggregated: ({ cell: { value } }) => `${value}`
-        }
+        }   
     ];
 
     const columnsToDisplay = columns;

--- a/frontend/src/main/components/PersonalSections/PersonalSectionsTable.js
+++ b/frontend/src/main/components/PersonalSections/PersonalSectionsTable.js
@@ -1,13 +1,8 @@
 import React from "react";
-// import OurTable, { ButtonColumn } from "main/components/OurTable";
 import SectionsTableBase from "main/components/SectionsTableBase";
 
 import { convertToFraction, formatDays, formatInstructors, formatLocation, formatTime } from "main/utils/sectionUtils.js";
 
-// import { useBackendMutation } from "main/utils/useBackend";
-// import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/PersonalScheduleUtils"
-// import { useNavigate } from "react-router-dom";
-// import { yyyyqToQyy } from "main/utils/quarterUtilities.js";
 
 function getFirstVal(values){
     return values[0];

--- a/frontend/src/stories/components/PersonalSections/PersonalSectionsTable.stories.js
+++ b/frontend/src/stories/components/PersonalSections/PersonalSectionsTable.stories.js
@@ -1,8 +1,8 @@
 import React from 'react';
 
 import PersonalSectionsTable from 'main/components/PersonalSections/PersonalSectionsTable';
-import { oneSection } from 'fixtures/personalSectionsFixtures';
-// import { currentUserFixtures } from 'fixtures/currentUserFixtures';
+import { oneSection, threeSections, fiveSections } from 'fixtures/personalSectionsFixtures';
+import { currentUserFixtures } from 'fixtures/currentUserFixtures';
 
 export default {
     title: 'components/PersonalSections/PersonalSectionsTable',
@@ -25,26 +25,25 @@ export const OneSection = Template.bind({});
 
 OneSection.args = {
     personalSections: oneSection
-    // currentUser: currentUserFixtures.adminUser
 };
 
-// export const ThreeSections = Template.bind({});
+export const ThreeSections = Template.bind({});
 
-// ThreeSections.args = {
-//     personalSections: personalSectionsFixtures.threePersonalSections
-// };
+ThreeSections.args = {
+    personalSections: threeSections
+};
 
-// export const FiveSections = Template.bind({});
+export const FiveSections = Template.bind({});
 
-// FiveSections.args = {
-//     personalSections: personalSectionsFixtures.fivePersonalSections
-// };
+FiveSections.args = {
+    personalSections: fiveSections
+};
 
 
 
-// export const ThreeSubjectsUser = Template.bind({});
-// ThreeSubjectsUser.args = {
-//     personalSections: personalSectionsFixtures.threePersonalSections,
-//     currentUser: currentUserFixtures.adminUser
-// };
+export const ThreeSubjectsUser = Template.bind({});
+ThreeSubjectsUser.args = {
+    personalSections: threeSections,
+    currentUser: currentUserFixtures.adminUser
+};
 

--- a/frontend/src/stories/components/PersonalSections/PersonalSectionsTable.stories.js
+++ b/frontend/src/stories/components/PersonalSections/PersonalSectionsTable.stories.js
@@ -1,8 +1,8 @@
 import React from 'react';
 
 import PersonalSectionsTable from 'main/components/PersonalSections/PersonalSectionsTable';
-import { personalSectionsFixtures } from 'fixtures/personalSectionsFixtures';
-import { currentUserFixtures } from 'fixtures/currentUserFixtures';
+import { oneSection } from 'fixtures/personalSectionsFixtures';
+// import { currentUserFixtures } from 'fixtures/currentUserFixtures';
 
 export default {
     title: 'components/PersonalSections/PersonalSectionsTable',
@@ -21,23 +21,24 @@ Empty.args = {
     personalSections: []
 };
 
-export const OneSection = Template.bind({});
+export const oneSection = Template.bind({});
 
-OneSection.args = {
-    sections: oneSection
+oneSection.args = {
+    personalSections: oneSection
+    // currentUser: currentUserFixtures.adminUser
 };
 
-export const ThreeSections = Template.bind({});
+// export const ThreeSections = Template.bind({});
 
-ThreeSections.args = {
-    personalSections: personalSectionsFixtures.threePersonalSections
-};
+// ThreeSections.args = {
+//     personalSections: personalSectionsFixtures.threePersonalSections
+// };
 
-export const FiveSections = Template.bind({});
+// export const FiveSections = Template.bind({});
 
-FiveSections.args = {
-    personalSections: personalSectionsFixtures.threePersonalSections
-};
+// FiveSections.args = {
+//     personalSections: personalSectionsFixtures.fivePersonalSections
+// };
 
 
 

--- a/frontend/src/stories/components/PersonalSections/PersonalSectionsTable.stories.js
+++ b/frontend/src/stories/components/PersonalSections/PersonalSectionsTable.stories.js
@@ -33,6 +33,13 @@ ThreeSections.args = {
     personalSections: personalSectionsFixtures.threePersonalSections
 };
 
+export const FiveSections = Template.bind({});
+
+FiveSections.args = {
+    personalSections: personalSectionsFixtures.threePersonalSections
+};
+
+
 
 // export const ThreeSubjectsUser = Template.bind({});
 // ThreeSubjectsUser.args = {

--- a/frontend/src/stories/components/PersonalSections/PersonalSectionsTable.stories.js
+++ b/frontend/src/stories/components/PersonalSections/PersonalSectionsTable.stories.js
@@ -1,0 +1,42 @@
+import React from 'react';
+
+import PersonalSectionsTable from 'main/components/PersonalSections/PersonalSectionsTable';
+import { personalSectionsFixtures } from 'fixtures/personalSectionsFixtures';
+import { currentUserFixtures } from 'fixtures/currentUserFixtures';
+
+export default {
+    title: 'components/PersonalSections/PersonalSectionsTable',
+    component: PersonalSectionsTable
+};
+
+const Template = (args) => {
+    return (
+        <PersonalSectionsTable {...args} />
+    )
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+    personalSections: []
+};
+
+export const OneSection = Template.bind({});
+
+OneSection.args = {
+    sections: oneSection
+};
+
+export const ThreeSections = Template.bind({});
+
+ThreeSections.args = {
+    personalSections: personalSectionsFixtures.threePersonalSections
+};
+
+
+// export const ThreeSubjectsUser = Template.bind({});
+// ThreeSubjectsUser.args = {
+//     personalSections: personalSectionsFixtures.threePersonalSections,
+//     currentUser: currentUserFixtures.adminUser
+// };
+

--- a/frontend/src/stories/components/PersonalSections/PersonalSectionsTable.stories.js
+++ b/frontend/src/stories/components/PersonalSections/PersonalSectionsTable.stories.js
@@ -21,9 +21,9 @@ Empty.args = {
     personalSections: []
 };
 
-export const oneSection = Template.bind({});
+export const OneSection = Template.bind({});
 
-oneSection.args = {
+OneSection.args = {
     personalSections: oneSection
     // currentUser: currentUserFixtures.adminUser
 };

--- a/frontend/src/tests/components/PersonalSections/PersonalSectionsTable.test.js
+++ b/frontend/src/tests/components/PersonalSections/PersonalSectionsTable.test.js
@@ -53,6 +53,7 @@ describe("PersonalSections tests", () => {
         expect(header).toBeInTheDocument();
       });
       expect(screen.getByTestId(`${testId}-cell-row-0-col-courseId`)).toHaveTextContent("ECE 5");
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-courseId`)).not.toHaveTextContent("ECE 5 "); // covers mutation of not successfully removing all whitespaces
       expect(screen.getByTestId(`${testId}-cell-row-0-col-classSections[0].enrollCode`)).toHaveTextContent("12591");
       expect(screen.getByTestId(`${testId}-cell-row-0-col-classSections[0].section`)).toHaveTextContent("0100");
       expect(screen.getByTestId(`${testId}-cell-row-0-col-title`)).toHaveTextContent("INTRO TO ECE");

--- a/frontend/src/tests/components/PersonalSections/PersonalSectionsTable.test.js
+++ b/frontend/src/tests/components/PersonalSections/PersonalSectionsTable.test.js
@@ -1,7 +1,8 @@
-import { fiveSections, gigaSections } from "fixtures/sectionFixtures";
+import { render, screen } from "@testing-library/react";
+import { fiveSections } from "fixtures/personalSectionsFixtures";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
-import SectionsTable from "main/components/Sections/SectionsTable";
+import PersonalSectionsTable from "main/components/PersonalSections/PersonalSectionsTable";
 
 
 const mockedNavigate = jest.fn();
@@ -11,7 +12,7 @@ jest.mock('react-router-dom', () => ({
     useNavigate: () => mockedNavigate
 }));
 
-describe("Section tests", () => {
+describe("PersonalSections tests", () => {
   const queryClient = new QueryClient();
 
 
@@ -20,68 +21,26 @@ describe("Section tests", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <SectionsTable sections={[]} />
+          <PersonalSectionsTable personalSections={[]} />
         </MemoryRouter>
       </QueryClientProvider>
 
     );
   });
 
-
-
-  test("Has the expected cell values when expanded", () => {
-
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <SectionsTable sections={fiveSections} />
-        </MemoryRouter>
-      </QueryClientProvider>
-
-    );
-
-
-    const expectedHeaders = ["Quarter",  "Course ID", "Title", "Enrolled", "Location", "Days", "Time", "Instructor", "Enroll Code"];
-    const expectedFields = ["quarter", "courseInfo.courseId", "courseInfo.title", "enrolled", "location", "days", "time", "instructor", "section.enrollCode"];
-    const testId = "SectionsTable";
-    
-
-    expectedHeaders.forEach((headerText) => {
-      const header = screen.getByText(headerText);
-      expect(header).toBeInTheDocument();
-    });
-
-    expectedFields.forEach((field) => {
-      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
-      expect(header).toBeInTheDocument();
-    });
-
-    const expandRow = screen.getByTestId(`${testId}-cell-row-1-col-courseInfo.courseId-expand-symbols`)
-    fireEvent.click(expandRow);
-
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-quarter`)).toHaveTextContent("W22");
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-time`)).toHaveTextContent("3:00 PM - 3:50 PM");
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-days`)).toHaveTextContent("M");
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-enrolled`)).toHaveTextContent("84/100");
-    expect(screen.getByTestId(`${testId}-cell-row-2-col-location`)).toHaveTextContent("HFH 1124");
-    expect(screen.getByTestId(`${testId}-cell-row-2-col-instructor`)).toHaveTextContent("YUNG A S");
-
-
-
-  });
 
   test("Has the expected column headers and content", async () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <SectionsTable sections={fiveSections} />
+          <PersonalSectionsTable personalSections={fiveSections} />
         </MemoryRouter>
       </QueryClientProvider>
       );
 
-      const expectedHeaders = ["Quarter",  "Course ID", "Title", "Enrolled", "Location", "Days", "Time", "Instructor", "Enroll Code"];
-      const expectedFields = ["quarter", "courseInfo.courseId", "courseInfo.title", "enrolled", "location", "days", "time", "instructor", "section.enrollCode"];
-      const testId = "SectionsTable";
+      const expectedHeaders = ["Course ID", "Enroll Code", "Section","Title", "Enrolled", "Location", "Days", "Time", "Instructor"];
+      const expectedFields = ["courseId", "classSections[0].enrollCode", "classSections[0].section","title", "enrolled", "location", "days", "time", "instructor"];
+      const testId = "PersonalSectionsTable";
 
       expectedHeaders.forEach((headerText) => {
         const header = screen.getByText(headerText);
@@ -93,15 +52,15 @@ describe("Section tests", () => {
         const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
         expect(header).toBeInTheDocument();
       });
-      expect(screen.getByTestId(`${testId}-cell-row-0-col-courseInfo.courseId`)).toHaveTextContent("ECE 1A");
-      expect(screen.getByTestId(`${testId}-cell-row-0-col-courseInfo.title`)).toHaveTextContent("COMP ENGR SEMINAR");
-      expect(screen.getByTestId(`${testId}-cell-row-0-col-quarter`)).toHaveTextContent("W22");
-      expect(screen.getByTestId(`${testId}-cell-row-0-col-time`)).toHaveTextContent("3:00 PM - 3:50 PM");
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-courseId`)).toHaveTextContent("ECE 5");
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-classSections[0].enrollCode`)).toHaveTextContent("12591");
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-classSections[0].section`)).toHaveTextContent("0100");
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-title`)).toHaveTextContent("INTRO TO ECE");
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-enrolled`)).toHaveTextContent("78/120");
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-location`)).toHaveTextContent("PHELP 1260");
       expect(screen.getByTestId(`${testId}-cell-row-0-col-days`)).toHaveTextContent("M");
-      expect(screen.getByTestId(`${testId}-cell-row-0-col-enrolled`)).toHaveTextContent("84/100");
-      expect(screen.getByTestId(`${testId}-cell-row-0-col-location`)).toHaveTextContent("BUCHN 1930");
-      expect(screen.getByTestId(`${testId}-cell-row-0-col-instructor`)).toHaveTextContent("WANG L C");
-      expect(screen.getByTestId(`${testId}-cell-row-0-col-section.enrollCode`)).toHaveTextContent("12583");
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-time`)).toHaveTextContent("12:30 PM - 1:45 PM");
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-instructor`)).toHaveTextContent("HESPANHA J P");
       
 
   });

--- a/frontend/src/tests/components/PersonalSections/PersonalSectionsTable.test.js
+++ b/frontend/src/tests/components/PersonalSections/PersonalSectionsTable.test.js
@@ -1,0 +1,111 @@
+import { fiveSections, gigaSections } from "fixtures/sectionFixtures";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import SectionsTable from "main/components/Sections/SectionsTable";
+
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+describe("Section tests", () => {
+  const queryClient = new QueryClient();
+
+
+  test("renders without crashing for empty table", () => {
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <SectionsTable sections={[]} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+  });
+
+
+
+  test("Has the expected cell values when expanded", () => {
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <SectionsTable sections={fiveSections} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+
+    const expectedHeaders = ["Quarter",  "Course ID", "Title", "Enrolled", "Location", "Days", "Time", "Instructor", "Enroll Code"];
+    const expectedFields = ["quarter", "courseInfo.courseId", "courseInfo.title", "enrolled", "location", "days", "time", "instructor", "section.enrollCode"];
+    const testId = "SectionsTable";
+    
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    const expandRow = screen.getByTestId(`${testId}-cell-row-1-col-courseInfo.courseId-expand-symbols`)
+    fireEvent.click(expandRow);
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-quarter`)).toHaveTextContent("W22");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-time`)).toHaveTextContent("3:00 PM - 3:50 PM");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-days`)).toHaveTextContent("M");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-enrolled`)).toHaveTextContent("84/100");
+    expect(screen.getByTestId(`${testId}-cell-row-2-col-location`)).toHaveTextContent("HFH 1124");
+    expect(screen.getByTestId(`${testId}-cell-row-2-col-instructor`)).toHaveTextContent("YUNG A S");
+
+
+
+  });
+
+  test("Has the expected column headers and content", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <SectionsTable sections={fiveSections} />
+        </MemoryRouter>
+      </QueryClientProvider>
+      );
+
+      const expectedHeaders = ["Quarter",  "Course ID", "Title", "Enrolled", "Location", "Days", "Time", "Instructor", "Enroll Code"];
+      const expectedFields = ["quarter", "courseInfo.courseId", "courseInfo.title", "enrolled", "location", "days", "time", "instructor", "section.enrollCode"];
+      const testId = "SectionsTable";
+
+      expectedHeaders.forEach((headerText) => {
+        const header = screen.getByText(headerText);
+        expect(header).toBeInTheDocument();
+      });
+
+
+      expectedFields.forEach((field) => {
+        const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+        expect(header).toBeInTheDocument();
+      });
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-courseInfo.courseId`)).toHaveTextContent("ECE 1A");
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-courseInfo.title`)).toHaveTextContent("COMP ENGR SEMINAR");
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-quarter`)).toHaveTextContent("W22");
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-time`)).toHaveTextContent("3:00 PM - 3:50 PM");
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-days`)).toHaveTextContent("M");
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-enrolled`)).toHaveTextContent("84/100");
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-location`)).toHaveTextContent("BUCHN 1930");
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-instructor`)).toHaveTextContent("WANG L C");
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-section.enrollCode`)).toHaveTextContent("12583");
+      
+
+  });
+
+
+});
+


### PR DESCRIPTION
## Overview

In this PR, we implement the ```PersonalSectionsTable``` component that takes a list of PersonalSection objects corresponding to the ```/api/personalSections/all``` endpoint.

Storybook link: https://ucsb-cs156-f22.github.io/f22-7pm-courses-docs-qa/storybook-qa/eemn-PersonalSchedule/?path=/docs/components-personalsections-personalsectionstable--empty

## Details

The table contains the following headers:

- Course ID
- Enroll Code
- Section
- Title
- Enrolled
- Location
- Days
- Time
- Instructor

Using the Storybook, we observe an empty PersonalSectionsTable:

<img width="1174" alt="Screen Shot 2022-11-28 at 7 13 02 PM" src="https://user-images.githubusercontent.com/75236585/204429704-e4ac3c20-127f-4b35-b8c7-6c29df3f6834.png">

We can also see when the table is populated with five sections:

<img width="1172" alt="Screen Shot 2022-11-28 at 7 13 20 PM" src="https://user-images.githubusercontent.com/75236585/204429748-37e9e499-feee-4594-8483-e22ca4b1524d.png">


This PR simply implements the PersonalSectionsTable component and tests for it, along with the Storybook and its fixtures. In a future PR, the PersonalSectionsTable component will be added into the ```PersonalSchedulesDetailPage```.

We also are currently passing all line coverage, tests, and mutation tests.

Closes #19 