### PR TITLE
Add a New Column for Section Number to the Table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,8 @@
 frontend/.stryker-tmp
 frontend/reports
 frontend/strykerTmp
-
+/.stryker-tmp
+.history
 # Don't check in a built storybook #
 
 frontend/storybook-static

--- a/frontend/src/main/components/Sections/SectionsTable.js
+++ b/frontend/src/main/components/Sections/SectionsTable.js
@@ -27,7 +27,7 @@ export default function SectionsTable({ sections }) {
         },
         {
             Header: 'Section',
-            accessor: (row) => boldIfNotSection(row.section.section),
+            accessor: (row, _rowIndex) => boldIfNotSection(row.section.section),
             id: 'section.section',
         },  
         {

--- a/frontend/src/main/components/Sections/SectionsTable.js
+++ b/frontend/src/main/components/Sections/SectionsTable.js
@@ -27,7 +27,7 @@ export default function SectionsTable({ sections }) {
         },
         {
             Header: 'Section',
-            accessor: (row, _rowIndex) => boldIfNotSection(row.section.section),
+            accessor: (row) => boldIfNotSection(row.section.section),
             id: 'section.section',
         },  
         {

--- a/frontend/src/main/components/Sections/SectionsTable.js
+++ b/frontend/src/main/components/Sections/SectionsTable.js
@@ -3,6 +3,8 @@ import SectionsTableBase from "main/components/SectionsTableBase";
 import { yyyyqToQyy } from "main/utils/quarterUtilities.js";
 import { convertToFraction, formatDays, formatInstructors, formatLocation, formatTime, isSection } from "main/utils/sectionUtils.js";
 
+import { boldIfNotSection } from "main/utils/sectionUtils";
+
 
 function getFirstVal(values) {
     return values[0];
@@ -23,6 +25,11 @@ export default function SectionsTable({ sections }) {
             aggregate: getFirstVal,
             Aggregated: ({ cell: { value } }) => `${value}`
         },
+        {
+            Header: 'Section',
+            accessor: (row, _rowIndex) => boldIfNotSection(row.section.section),
+            id: 'section.section',
+        },  
         {
             Header: 'Course ID',
             accessor: 'courseInfo.courseId',

--- a/frontend/src/main/components/SectionsTableBase.js
+++ b/frontend/src/main/components/SectionsTableBase.js
@@ -2,7 +2,8 @@ import React from "react";
 import { useTable, useGroupBy, useExpanded } from 'react-table'
 import { Table } from "react-bootstrap";
 
-
+const COURSE_ID_COLUMN = 0
+const ENROLLED_NUM_COLUMN = 4
 // Stryker disable StringLiteral, ArrayDeclaration
 export default function SectionsTableBase({ columns, data, testid = "testid"}) {
   
@@ -30,7 +31,7 @@ export default function SectionsTableBase({ columns, data, testid = "testid"}) {
           prepareRow(row)
           return (
             <>
-            {row.cells[0].isGrouped || (!row.cells[0].isGrouped && row.allCells[4].value) ? 
+            {row.cells[COURSE_ID_COLUMN].isGrouped || (!row.cells[COURSE_ID_COLUMN].isGrouped && row.allCells[ENROLLED_NUM_COLUMN].value) ? 
             <tr {...row.getRowProps()}>
               {row.cells.map((cell, _index) => {
                 return (

--- a/frontend/src/main/components/SectionsTableBase.js
+++ b/frontend/src/main/components/SectionsTableBase.js
@@ -2,8 +2,8 @@ import React from "react";
 import { useTable, useGroupBy, useExpanded } from 'react-table'
 import { Table } from "react-bootstrap";
 
-const COURSE_ID_COLUMN = 0
-const ENROLLED_NUM_COLUMN = 4
+const COURSE_ID_COLUMN = 0;
+const ENROLLED_NUM_COLUMN = 4;
 // Stryker disable StringLiteral, ArrayDeclaration
 export default function SectionsTableBase({ columns, data, testid = "testid"}) {
   

--- a/frontend/src/main/components/SectionsTableBase.js
+++ b/frontend/src/main/components/SectionsTableBase.js
@@ -30,7 +30,7 @@ export default function SectionsTableBase({ columns, data, testid = "testid"}) {
           prepareRow(row)
           return (
             <>
-            {row.cells[0].isGrouped || (!row.cells[0].isGrouped && row.allCells[3].value) ? 
+            {row.cells[0].isGrouped || (!row.cells[0].isGrouped && row.allCells[4].value) ? 
             <tr {...row.getRowProps()}>
               {row.cells.map((cell, _index) => {
                 return (

--- a/frontend/src/main/utils/sectionUtils.js
+++ b/frontend/src/main/utils/sectionUtils.js
@@ -2,19 +2,20 @@ import { hhmmTohhmma, convertToTimeRange } from "main/utils/timeUtils.js"
 
 export const boldIfNotSection = (code) => {
     let n = parseInt(code);
-    if (n % 100 !== 0) 
-    {
-        return code;
-    }
-    else if (isNaN(n)) 
+    if (isNaN(n)) 
     {
         throw new Error("The parameter must be a number!");
+    }
+    else if (n % 100 !== 0) 
+    {
+        return code;
     }
     else 
     {
         return (<div style={{fontWeight: "bold"}}>{code}</div>)
     }
 }
+
 
 
 export const convertToFraction = (en1, en2) => {

--- a/frontend/src/main/utils/sectionUtils.js
+++ b/frontend/src/main/utils/sectionUtils.js
@@ -16,8 +16,6 @@ export const boldIfNotSection = (code) => {
     }
 }
 
-
-
 export const convertToFraction = (en1, en2) => {
     return (en1 != null && en2 != null) ? `${en1}/${en2}` : "";
 }

--- a/frontend/src/main/utils/sectionUtils.js
+++ b/frontend/src/main/utils/sectionUtils.js
@@ -1,9 +1,25 @@
 import { hhmmTohhmma, convertToTimeRange } from "main/utils/timeUtils.js"
 
+export const boldIfNotSection = (code) => {
+    let n = parseInt(code);
+    if (n % 100 !== 0) 
+    {
+        return code;
+    }
+    else if (isNaN(n)) 
+    {
+        throw new Error("The parameter must be a number!");
+    }
+    else 
+    {
+        return (<div style={{fontWeight: "bold"}}>{code}</div>)
+    }
+}
+
+
 export const convertToFraction = (en1, en2) => {
     return (en1 != null && en2 != null) ? `${en1}/${en2}` : "";
 }
-
 
 // Takes a time location array and returns the locations
 export const formatLocation = (timeLocationArray) => {

--- a/frontend/src/tests/components/Sections/SectionsTable.test.js
+++ b/frontend/src/tests/components/Sections/SectionsTable.test.js
@@ -42,10 +42,9 @@ describe("Section tests", () => {
     );
 
 
-    const expectedHeaders = ["Quarter",  "Course ID", "Title", "Enrolled", "Location", "Days", "Time", "Instructor", "Enroll Code"];
-    const expectedFields = ["quarter", "courseInfo.courseId", "courseInfo.title", "enrolled", "location", "days", "time", "instructor", "section.enrollCode"];
+    const expectedHeaders = ["Quarter", "Section", "Course ID", "Title", "Enrolled", "Location", "Days", "Time", "Instructor", "Enroll Code"];
+    const expectedFields = ["quarter",  "section.section", "courseInfo.courseId", "courseInfo.title", "enrolled", "location", "days", "time", "instructor", "section.enrollCode"];
     const testId = "SectionsTable";
-    
 
     expectedHeaders.forEach((headerText) => {
       const header = screen.getByText(headerText);
@@ -61,6 +60,7 @@ describe("Section tests", () => {
     fireEvent.click(expandRow);
 
     expect(screen.getByTestId(`${testId}-cell-row-0-col-quarter`)).toHaveTextContent("W22");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-section.section`)).toHaveTextContent("0101");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-time`)).toHaveTextContent("3:00 PM - 3:50 PM");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-days`)).toHaveTextContent("M");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-enrolled`)).toHaveTextContent("84/100");
@@ -80,8 +80,8 @@ describe("Section tests", () => {
       </QueryClientProvider>
       );
 
-      const expectedHeaders = ["Quarter",  "Course ID", "Title", "Enrolled", "Location", "Days", "Time", "Instructor", "Enroll Code"];
-      const expectedFields = ["quarter", "courseInfo.courseId", "courseInfo.title", "enrolled", "location", "days", "time", "instructor", "section.enrollCode"];
+      const expectedHeaders = ["Quarter",  "Section","Course ID", "Title", "Enrolled", "Location", "Days", "Time", "Instructor", "Enroll Code"];
+      const expectedFields = ["quarter", "section.section","courseInfo.courseId", "courseInfo.title", "enrolled", "location", "days", "time", "instructor", "section.enrollCode"];
       const testId = "SectionsTable";
 
       expectedHeaders.forEach((headerText) => {
@@ -97,6 +97,7 @@ describe("Section tests", () => {
       expect(screen.getByTestId(`${testId}-cell-row-0-col-courseInfo.courseId`)).toHaveTextContent("ECE 1A");
       expect(screen.getByTestId(`${testId}-cell-row-0-col-courseInfo.title`)).toHaveTextContent("COMP ENGR SEMINAR");
       expect(screen.getByTestId(`${testId}-cell-row-0-col-quarter`)).toHaveTextContent("W22");
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-section.section`)).toHaveTextContent("0101");
       expect(screen.getByTestId(`${testId}-cell-row-0-col-time`)).toHaveTextContent("3:00 PM - 3:50 PM");
       expect(screen.getByTestId(`${testId}-cell-row-0-col-days`)).toHaveTextContent("M");
       expect(screen.getByTestId(`${testId}-cell-row-0-col-enrolled`)).toHaveTextContent("84/100");
@@ -104,7 +105,6 @@ describe("Section tests", () => {
       expect(screen.getByTestId(`${testId}-cell-row-0-col-instructor`)).toHaveTextContent("WANG L C");
       expect(screen.getByTestId(`${testId}-cell-row-0-col-section.enrollCode`)).toHaveTextContent("12583");
       
-
   });
 
   test("Correctly groups separate lectures of the same class", async () => {

--- a/frontend/src/tests/components/Sections/SectionsTable.test.js
+++ b/frontend/src/tests/components/Sections/SectionsTable.test.js
@@ -60,7 +60,7 @@ describe("Section tests", () => {
     fireEvent.click(expandRow);
 
     expect(screen.getByTestId(`${testId}-cell-row-0-col-quarter`)).toHaveTextContent("W22");
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-section.section`)).toHaveTextContent("0101");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-section.section`)).toHaveTextContent("0100");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-time`)).toHaveTextContent("3:00 PM - 3:50 PM");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-days`)).toHaveTextContent("M");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-enrolled`)).toHaveTextContent("84/100");
@@ -97,7 +97,7 @@ describe("Section tests", () => {
       expect(screen.getByTestId(`${testId}-cell-row-0-col-courseInfo.courseId`)).toHaveTextContent("ECE 1A");
       expect(screen.getByTestId(`${testId}-cell-row-0-col-courseInfo.title`)).toHaveTextContent("COMP ENGR SEMINAR");
       expect(screen.getByTestId(`${testId}-cell-row-0-col-quarter`)).toHaveTextContent("W22");
-      expect(screen.getByTestId(`${testId}-cell-row-0-col-section.section`)).toHaveTextContent("0101");
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-section.section`)).toHaveTextContent("0100");
       expect(screen.getByTestId(`${testId}-cell-row-0-col-time`)).toHaveTextContent("3:00 PM - 3:50 PM");
       expect(screen.getByTestId(`${testId}-cell-row-0-col-days`)).toHaveTextContent("M");
       expect(screen.getByTestId(`${testId}-cell-row-0-col-enrolled`)).toHaveTextContent("84/100");

--- a/frontend/src/tests/components/Sections/SectionsTable.test.js
+++ b/frontend/src/tests/components/Sections/SectionsTable.test.js
@@ -60,7 +60,7 @@ describe("Section tests", () => {
     fireEvent.click(expandRow);
 
     expect(screen.getByTestId(`${testId}-cell-row-0-col-quarter`)).toHaveTextContent("W22");
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-section.section`)).toHaveTextContent("0100");
+    expect(screen.getByTestId(`${testId}-cell-row-2-col-section.section`)).toHaveTextContent("0101");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-time`)).toHaveTextContent("3:00 PM - 3:50 PM");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-days`)).toHaveTextContent("M");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-enrolled`)).toHaveTextContent("84/100");
@@ -97,7 +97,7 @@ describe("Section tests", () => {
       expect(screen.getByTestId(`${testId}-cell-row-0-col-courseInfo.courseId`)).toHaveTextContent("ECE 1A");
       expect(screen.getByTestId(`${testId}-cell-row-0-col-courseInfo.title`)).toHaveTextContent("COMP ENGR SEMINAR");
       expect(screen.getByTestId(`${testId}-cell-row-0-col-quarter`)).toHaveTextContent("W22");
-      expect(screen.getByTestId(`${testId}-cell-row-0-col-section.section`)).toHaveTextContent("0100");
+      expect(screen.getByTestId(`${testId}-cell-row-1-col-section.section`)).toHaveTextContent("");
       expect(screen.getByTestId(`${testId}-cell-row-0-col-time`)).toHaveTextContent("3:00 PM - 3:50 PM");
       expect(screen.getByTestId(`${testId}-cell-row-0-col-days`)).toHaveTextContent("M");
       expect(screen.getByTestId(`${testId}-cell-row-0-col-enrolled`)).toHaveTextContent("84/100");
@@ -142,7 +142,7 @@ describe("Section tests", () => {
       const expandRow = screen.getByTestId(`${testId}-cell-row-1-col-courseInfo.courseId-expand-symbols`)
       fireEvent.click(expandRow);
 
-      expect(screen.getByTestId(`${testId}-cell-row-1-col-enrolled`)).toHaveTextContent("84/80");
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-enrolled`)).toHaveTextContent("84/100");
       expect(screen.getByTestId(`${testId}-cell-row-2-col-enrolled`)).toHaveTextContent("21/21");
   });
 

--- a/frontend/src/tests/utils/sectionUtils.test.js
+++ b/frontend/src/tests/utils/sectionUtils.test.js
@@ -53,7 +53,7 @@ const testInstructors = [
 describe("To bold tests", () => {
     test("If correct number bolds", () => {
         expect(boldIfNotSection("1000")).toStrictEqual(<div style={{fontWeight: "bold"}}>1000</div>);
-        expect(() => {boldIfNotSection("abc"); }).toThrow("The parameter must be a number");
+        expect(() => {boldIfNotSection("abc"); }).toThrow("The parameter must be a number!");
         expect(boldIfNotSection("1001")).toBe("1001");
     });
 });

--- a/frontend/src/tests/utils/sectionUtils.test.js
+++ b/frontend/src/tests/utils/sectionUtils.test.js
@@ -1,4 +1,5 @@
 import {convertToFraction, formatLocation, isSection, formatDays, formatTime, formatInstructors} from "main/utils/sectionUtils"
+import { boldIfNotSection } from "main/utils/sectionUtils";
 
 const testTimeLocations = [
     {
@@ -48,6 +49,14 @@ const testInstructors = [
         "functionCode": "Teaching and in charge"
     }
 ]
+
+describe("To bold tests", () => {
+    test("If correct number bolds", () => {
+        expect(boldIfNotSection("2000")).toStrictEqual(<div style={{fontWeight: "bold"}}>2000</div>);
+        expect(() => {boldIfNotSection("abc"); }).toThrow("param should be a number");
+        expect(boldIfNotSection("2002")).toBe("2002");
+    });
+});
 
 describe ("section utils tests", () => {
     test("convertToFraction one null test 1" , () => {

--- a/frontend/src/tests/utils/sectionUtils.test.js
+++ b/frontend/src/tests/utils/sectionUtils.test.js
@@ -52,9 +52,9 @@ const testInstructors = [
 
 describe("To bold tests", () => {
     test("If correct number bolds", () => {
-        expect(boldIfNotSection("2000")).toStrictEqual(<div style={{fontWeight: "bold"}}>2000</div>);
-        expect(() => {boldIfNotSection("abc"); }).toThrow("param should be a number");
-        expect(boldIfNotSection("2002")).toBe("2002");
+        expect(boldIfNotSection("1000")).toStrictEqual(<div style={{fontWeight: "bold"}}>1000</div>);
+        expect(() => {boldIfNotSection("abc"); }).toThrow("The parameter must be a number");
+        expect(boldIfNotSection("1001")).toBe("1001");
     });
 });
 

--- a/frontend/src/tests/utils/sectionUtils.test.js
+++ b/frontend/src/tests/utils/sectionUtils.test.js
@@ -52,9 +52,9 @@ const testInstructors = [
 
 describe("To bold tests", () => {
     test("If correct number bolds", () => {
-        expect(boldIfNotSection("1000")).toStrictEqual(<div style={{fontWeight: "bold"}}>1000</div>);
+        expect(boldIfNotSection("2000")).toStrictEqual(<div style={{fontWeight: "bold"}}>2000</div>);
         expect(() => {boldIfNotSection("abc"); }).toThrow("The parameter must be a number!");
-        expect(boldIfNotSection("1001")).toBe("1001");
+        expect(boldIfNotSection("2002")).toBe("2002");
     });
 });
 


### PR DESCRIPTION
In this PR, I added a new column for the ID of each section and made the IDs bold in order to represent courses. It passed all the tests.

Deployment on QA:
<img width="1432" alt="image" src="https://user-images.githubusercontent.com/64247457/204736723-de1e1815-d291-4ed4-9f30-0d5a8411d7fa.png">

Here is the storybook:
https://ucsb-cs156-f22.github.io/f22-7pm-courses-docs-qa/storybook-qa/Mason-AddSectionNumber/?path=/docs/components-sections-sectionstable--empty

Close #42