### PR TITLE
AG & HY -Personal Schedule Edit Page Implementation

### DIFF
--- a/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
+++ b/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
@@ -1,15 +1,75 @@
-
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router-dom";
+import PersonalScheduleForm from "main/components/PersonalSchedules/PersonalScheduleForm";
+import { Navigate } from 'react-router-dom'
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function PersonalSchedulesEditPage() {
-    return (
-        <BasicLayout>
-            <div className="pt-2">
-                <h1>PersonalSchedules</h1>
-                <p>
-                    This is where the edit page will go
-                </p>
-            </div>
-        </BasicLayout>
-    )
+export default function PersonalScheduleEditPage() {
+  let { id } = useParams();
+
+  const { data: personalSchedule, _error, _status } =
+    useBackend(
+      // Stryker disable next-line all : don't test internal caching of React Query
+      [`/api/personalschedules?id=${id}`],
+      {  // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
+        method: "GET",
+        url: `/api/personalschedules`,
+        params: {
+          id
+        }
+      }
+    );
+
+
+  const objectToAxiosPutParams = (personalSchedule) => ({
+    url: "/api/personalschedules",
+    method: "PUT",
+    params: {
+      id: personalSchedule.id,
+    },
+    data: {
+      user: personalSchedule.user,
+      name: personalSchedule.name,
+      description: personalSchedule.description,
+      quarter: personalSchedule.quarter,
+    }
+  });
+
+  const onSuccess = (personalSchedule) => {
+    toast(`PersonalSchedule Updated - id: ${personalSchedule.id} name: ${personalSchedule.name}`);
+    console.log(personalSchedule.quarter)
+  }
+
+  const mutation = useBackendMutation(
+    objectToAxiosPutParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    [`/api/personalschedules?id=${id}`]
+  );
+
+  const { isSuccess } = mutation
+
+  const onSubmit = async (data) => {
+    const quarter = {
+        quarter: localStorage["PersonalScheduleForm-quarter"]
+    }
+    const dataFinal = Object.assign(data, quarter)
+    mutation.mutate(dataFinal);
+  }
+
+  if (isSuccess) {
+    return <Navigate to="/personalschedules/list" />
+  }
+
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Edit Personal Schedule</h1>
+        {personalSchedule &&
+          <PersonalScheduleForm initialPersonalSchedule={personalSchedule} submitAction={onSubmit} buttonLabel="Update" />
+        }
+      </div>
+    </BasicLayout>
+  )
 }

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
@@ -1,28 +1,134 @@
-import { render } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
-import PersonalSchedulesEditPage from "main/pages/PersonalSchedules/PersonalSchedulesEditPage";
-
-import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
-import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
-describe("PersonalSchedulesEditPage tests", () => {
+import PersonalScheduleEditPage from "main/pages/PersonalSchedules/PersonalSchedulesEditPage";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 
-    const axiosMock = new AxiosMockAdapter(axios);
-    axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
-    axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
 
-    const queryClient = new QueryClient();
-    test("renders without crashing", () => {
-        render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <PersonalSchedulesEditPage />
-                </MemoryRouter>
-            </QueryClientProvider>
-        );
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        useParams: () => ({
+            id: 5
+        }),
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
+
+describe("PersonalScheduleEditPage tests", () => {
+    describe("tests where backend is working normally", () => {
+        const axiosMock = new AxiosMockAdapter(axios);
+
+        beforeEach(() => {
+            axiosMock.reset();
+            axiosMock.resetHistory();
+            axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+            axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/personalschedules", { params: { id: 5 } }).reply(200, {
+                "id": 5,
+                "name": "TestName",
+                "description": "TestDescription",
+                "quarter": "20222"
+            });
+            axiosMock.onPut('/api/personalschedules').reply(200, {
+                "id": 5,
+                "name": "TestName2",
+                "description": "TestDescription2",
+                "quarter": "20221"
+            });
+        });
+
+        const queryClient = new QueryClient();
+        test("renders without crashing", () => {
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <PersonalScheduleEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+        });
+
+        test("Is populated with the data provided", async () => {
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <PersonalScheduleEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+
+            expect(await screen.findByLabelText(/Id/)).toBeInTheDocument();
+
+            const nameField = screen.getByLabelText(/Name/);
+            const descriptionField = screen.getByLabelText(/Description/);
+            const selectQuarter = screen.getByLabelText("Quarter");
+            userEvent.selectOptions(selectQuarter, "20222");
+            
+
+            expect(nameField).toHaveValue("TestName");
+            expect(descriptionField).toHaveValue("TestDescription")
+            expect(selectQuarter.value).toBe("20222");
+        });
+
+        test("Changes when you click Update", async () => {
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <PersonalScheduleEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+
+            expect(await screen.findByLabelText(/Id/)).toBeInTheDocument();
+
+            const nameField = screen.getByLabelText(/Name/);
+            const descriptionField = screen.getByLabelText(/Description/);
+            const selectQuarter = screen.getByLabelText("Quarter");
+            userEvent.selectOptions(selectQuarter, "20222");
+            
+            expect(nameField).toHaveValue("TestName");
+            expect(descriptionField).toHaveValue("TestDescription")
+            expect(selectQuarter.value).toBe("20222");
+
+            const submitButton = screen.getByText("Update");
+
+            expect(submitButton).toBeInTheDocument();
+
+            fireEvent.change(nameField, { target: { value: "TestName2" } })
+            fireEvent.change(descriptionField, { target: { value: "TestDescription2" } })
+            fireEvent.change(selectQuarter, { target: { value: "20221" } })
+            
+            fireEvent.click(submitButton);
+
+            await waitFor(() => expect(mockToast).toHaveBeenCalled());
+            expect(mockToast).toBeCalledWith("PersonalSchedule Updated - id: 5 name: TestName2");
+            expect(mockNavigate).toBeCalledWith({ "to": "/personalschedules/list" });
+
+            expect(axiosMock.history.put.length).toBe(1); // times called
+            expect(axiosMock.history.put[0].params).toEqual({ id: 5 });
+            expect(axiosMock.history.put[0].data).toBe(JSON.stringify({
+                "name": "TestName2",
+                "description" : "TestDescription2",
+                "quarter" : "20221"
+            })); // posted object
+        });
     });
-
 });


### PR DESCRIPTION
<h1>Overview</h1>
In this PR, the placeholder for the edit page was replaced with a functioning edit page that allows the editing of existing personal schedules.
<h1>Before:</h1>

![image](https://user-images.githubusercontent.com/77651728/204737382-cc9699ac-b84e-4425-a375-f580c1271d98.png)

<h1>After:</h1>

![image](https://user-images.githubusercontent.com/77651728/204733125-89b0f93f-dfb4-4450-97d6-6d006d96b152.png)
