### PR TITLE
MN & EE - Add PersonalSectionsTable to PersonalScheduleDetailsPage

### DIFF
--- a/frontend/src/fixtures/personalSectionsFixtures.js
+++ b/frontend/src/fixtures/personalSectionsFixtures.js
@@ -537,3 +537,127 @@ export const fiveSections = [
     "title": "PROBLEM SOLVING I"
   }
 ]
+
+export const sectionSuffix = [
+  {
+    "classSections": [
+      {
+        "classClosed": "string",
+        "concurrentCourses": [
+          "string"
+        ],
+        "courseCancelled": "string",
+        "departmentApprovalRequired": true,
+        "enrollCode": "12345",
+        "enrolledTotal": 83,
+        "gradingOptionCode": "string",
+        "instructorApprovalRequired": true,
+        "instructors": [
+          {
+            "functionCode": "string",
+            "instructor": "WANG L C"
+          }
+        ],
+        "maxEnroll": 100,
+        "restrictionLevel": "string",
+        "restrictionMajor": "string",
+        "restrictionMajorPass": "string",
+        "restrictionMinor": "string",
+        "restrictionMinorPass": "string",
+        "secondaryStatus": "string",
+        "section": "0100",
+        "session": "string",
+        "timeLocations": [
+          {
+            "beginTime": "15:30",
+            "building": "HFH",
+            "days": "M W    ",
+            "endTime": "16:45",
+            "room": "1104",
+            "roomCapacity": "string"
+          }
+        ]
+      }
+    ],
+    "courseId": "ECE       1A -1",
+    "description": "string",
+    "finalExam": {
+      "beginTime": "string",
+      "comments": "string",
+      "endTime": "string",
+      "examDate": "string",
+      "examDay": "string",
+      "hasFinals": true
+    },
+    "generalEducation": [
+      {
+        "geCode": "string",
+        "geCollege": "string"
+      }
+    ],
+    "quarter": "string",
+    "title": "COMP ENGR SEMINAR"
+  }
+]
+
+export const sectionNoSuffix = [
+  {
+    "classSections": [
+      {
+        "classClosed": "string",
+        "concurrentCourses": [
+          "string"
+        ],
+        "courseCancelled": "string",
+        "departmentApprovalRequired": true,
+        "enrollCode": "12345",
+        "enrolledTotal": 83,
+        "gradingOptionCode": "string",
+        "instructorApprovalRequired": true,
+        "instructors": [
+          {
+            "functionCode": "string",
+            "instructor": "WANG L C"
+          }
+        ],
+        "maxEnroll": 100,
+        "restrictionLevel": "string",
+        "restrictionMajor": "string",
+        "restrictionMajorPass": "string",
+        "restrictionMinor": "string",
+        "restrictionMinorPass": "string",
+        "secondaryStatus": "string",
+        "section": "0100",
+        "session": "string",
+        "timeLocations": [
+          {
+            "beginTime": "15:30",
+            "building": "HFH",
+            "days": "M W    ",
+            "endTime": "16:45",
+            "room": "1104",
+            "roomCapacity": "string"
+          }
+        ]
+      }
+    ],
+    "courseId": "ECE       1A ",
+    "description": "string",
+    "finalExam": {
+      "beginTime": "string",
+      "comments": "string",
+      "endTime": "string",
+      "examDate": "string",
+      "examDay": "string",
+      "hasFinals": true
+    },
+    "generalEducation": [
+      {
+        "geCode": "string",
+        "geCollege": "string"
+      }
+    ],
+    "quarter": "string",
+    "title": "COMP ENGR SEMINAR"
+  }
+]

--- a/frontend/src/main/components/PersonalSections/PersonalSectionsTable.js
+++ b/frontend/src/main/components/PersonalSections/PersonalSectionsTable.js
@@ -10,7 +10,7 @@ export default function PersonalSectionsTable({ personalSections }) {
     // Stryker enable all 
     // Stryker disable BooleanLiteral
     const removeSuffix = (s) => {
-        if (s.charAt(s.length - 2) == '-') {
+        if (s.charAt(s.length - 2) === '-') {
             return s.substring(0, s.length - 2);
         }
         return s;

--- a/frontend/src/main/components/PersonalSections/PersonalSectionsTable.js
+++ b/frontend/src/main/components/PersonalSections/PersonalSectionsTable.js
@@ -9,12 +9,19 @@ export default function PersonalSectionsTable({ personalSections }) {
 
     // Stryker enable all 
     // Stryker disable BooleanLiteral
+    const removeSuffix = (s) => {
+        if (s.charAt(s.length - 2) == '-') {
+            return s.substring(0, s.length - 2);
+        }
+        return s;
+    };
+
     const columns = [
         {
             Header: 'Course ID',
             accessor: 'courseId',
 
-            Cell: ({ cell: { value } }) => value.substring(0, value.length-2)
+            Cell: ({ cell: { value } }) => removeSuffix(value)
         },
         {
             Header: 'Enroll Code',

--- a/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesDetailsPage.js
+++ b/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesDetailsPage.js
@@ -2,12 +2,13 @@ import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import { useParams } from "react-router-dom";
 import PersonalSchedulesTable from 'main/components/PersonalSchedules/PersonalSchedulesTable';
 import { useBackend, _useBackendMutation } from "main/utils/useBackend";
+import PersonalSectionsTable from "main/components/PersonalSections/PersonalSectionsTable";
 
 
 export default function PersonalSchedulesDetailsPage() {
   let { id } = useParams();
 
-  const { data: personalSchedule, _error, _status } =
+  const { data: personalSchedule, _scheduleError, _scheduleStatus } =
     useBackend(
         // Stryker disable all : hard to test for query caching
       [`/api/personalschedules?id=${id}`],
@@ -20,6 +21,19 @@ export default function PersonalSchedulesDetailsPage() {
       }
     );
 
+  const { data: personalSections, _error, _status } =
+  useBackend(
+      // Stryker disable all : hard to test for query caching
+    [`/api/personalSections/all`],
+    {  // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
+      method: "GET",
+      url: `/api/personalSections/all?psId=${id}`,
+      params: {
+        id
+      }
+    }
+  );
+
   return (
     <BasicLayout>
       <div className="pt-2">
@@ -27,9 +41,8 @@ export default function PersonalSchedulesDetailsPage() {
         {personalSchedule &&
                 <PersonalSchedulesTable personalSchedules={[personalSchedule]} showButtons={false} />
             }
-            <p>
-                This is where the list of courses will go (from PersonalSectionsTable)
-            </p>
+        {personalSections && <PersonalSectionsTable personalSections={personalSections} />
+            }
       </div>
     </BasicLayout>
   )

--- a/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesDetailsPage.js
+++ b/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesDetailsPage.js
@@ -28,7 +28,7 @@ export default function PersonalSchedulesDetailsPage() {
                 <PersonalSchedulesTable personalSchedules={[personalSchedule]} showButtons={false} />
             }
             <p>
-                This is where the list of courses will go 
+                This is where the list of courses will go (from PersonalSectionsTable)
             </p>
       </div>
     </BasicLayout>

--- a/frontend/src/tests/components/PersonalSections/PersonalSectionsTable.test.js
+++ b/frontend/src/tests/components/PersonalSections/PersonalSectionsTable.test.js
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { fiveSections } from "fixtures/personalSectionsFixtures";
+import { fiveSections, sectionSuffix, sectionNoSuffix } from "fixtures/personalSectionsFixtures";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import PersonalSectionsTable from "main/components/PersonalSections/PersonalSectionsTable";
@@ -67,5 +67,61 @@ describe("PersonalSections tests", () => {
   });
 
 
+  test("Has the expected Course ID when courseId has suffix", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PersonalSectionsTable personalSections={sectionSuffix} />
+        </MemoryRouter>
+      </QueryClientProvider>
+      );
+
+      const expectedHeaders = ["Course ID", "Enroll Code", "Section","Title", "Enrolled", "Location", "Days", "Time", "Instructor"];
+      const expectedFields = ["courseId", "classSections[0].enrollCode", "classSections[0].section","title", "enrolled", "location", "days", "time", "instructor"];
+      const testId = "PersonalSectionsTable";
+
+      expectedHeaders.forEach((headerText) => {
+        const header = screen.getByText(headerText);
+        expect(header).toBeInTheDocument();
+      });
+
+
+      expectedFields.forEach((field) => {
+        const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+        expect(header).toBeInTheDocument();
+      });
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-courseId`)).toHaveTextContent("ECE 1A");
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-courseId`)).not.toHaveTextContent("ECE 1A -1"); // covers mutation of not successfully removing all whitespaces
+
+  });
+
+
+  test("Has the expected Course ID when courseId does not have suffix", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PersonalSectionsTable personalSections={sectionNoSuffix} />
+        </MemoryRouter>
+      </QueryClientProvider>
+      );
+
+      const expectedHeaders = ["Course ID", "Enroll Code", "Section","Title", "Enrolled", "Location", "Days", "Time", "Instructor"];
+      const expectedFields = ["courseId", "classSections[0].enrollCode", "classSections[0].section","title", "enrolled", "location", "days", "time", "instructor"];
+      const testId = "PersonalSectionsTable";
+
+      expectedHeaders.forEach((headerText) => {
+        const header = screen.getByText(headerText);
+        expect(header).toBeInTheDocument();
+      });
+
+
+      expectedFields.forEach((field) => {
+        const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+        expect(header).toBeInTheDocument();
+      });
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-courseId`)).toHaveTextContent("ECE 1A");
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-courseId`)).not.toHaveTextContent("ECE 1A -1"); // covers mutation of not successfully removing all whitespaces
+
+  });
 });
 

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesDetailsPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesDetailsPage.test.js
@@ -35,6 +35,7 @@ describe("PersonalSchedulesDetailsPage tests", () => {
     const axiosMock = new AxiosMockAdapter(axios);
 
     const testId = "PersonalSchedulesTable";
+    const sectionsTestId = "PersonalSectionsTable";
 
     const setupAdminUser = () => {
         axiosMock.reset();
@@ -106,6 +107,133 @@ describe("PersonalSchedulesDetailsPage tests", () => {
         expect(screen.getByTestId(`${testId}-cell-row-0-col-description`)).toHaveTextContent("My Winter Courses");
         expect(screen.getByTestId(`${testId}-cell-row-0-col-name`)).toHaveTextContent("CS156");
 
+    });
+
+    test("shows the correct info for admin users with added section", async() => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet(`/api/personalschedules?id=17`).reply(200, {
+                "id": 17,
+                "user": {
+                  "id": 1,
+                  "email": "phtcon@ucsb.edu",
+                  "googleSub": "115856948234298493496",
+                  "pictureUrl": "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
+                  "fullName": "Phill Conrad",
+                  "givenName": "Phill",
+                  "familyName": "Conrad",
+                  "emailVerified": true,
+                  "locale": "en",
+                  "hostedDomain": "ucsb.edu",
+                  "admin": true
+                },
+                "description": "My Winter Courses",
+                "quarter": "20221",
+                "name": "CS156"
+              
+        });
+
+        // add ECE 15A (enrollCd 12815 for W22)
+        axiosMock.onPost('/api/courses/post?enrollCd=12815&psId=1').reply(200, {
+            "id": 17,
+            "user": {
+              "id": 1,
+              "email": "phtcon@ucsb.edu",
+              "googleSub": "115856948234298493496",
+              "pictureUrl": "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
+              "fullName": "Phill Conrad",
+              "givenName": "Phill",
+              "familyName": "Conrad",
+              "emailVerified": true,
+              "locale": "en",
+              "hostedDomain": "ucsb.edu",
+              "admin": true
+            },
+            "enrollCd": "12815",
+            "psId": 1 
+        });
+
+        // axiosMock.onGet('/api/personalSections/all').reply(200, [
+        //     {
+        //       "quarter": "20221",
+        //       "courseId": "ECE      15A ",
+        //       "title": "FUND OF LOGIC DES",
+        //       "description": "Boolean algebra, logic of propositions, minterm and maxterm   expansions, Karnaugh maps, Quine-McCluskey method, melti-level circuits, combinational   circuit design and simulation, multiplexers, decoders, programmable logic   devices.",
+        //       "classSections": [
+        //         {
+        //           "enrollCode": "12815",
+        //           "section": "0107",
+        //           "session": null,
+        //           "classClosed": null,
+        //           "courseCancelled": null,
+        //           "gradingOptionCode": null,
+        //           "enrolledTotal": 23,
+        //           "maxEnroll": 23,
+        //           "secondaryStatus": null,
+        //           "departmentApprovalRequired": false,
+        //           "instructorApprovalRequired": false,
+        //           "restrictionLevel": null,
+        //           "restrictionMajor": "+EE   +ECE  +CMPEN+PRCME",
+        //           "restrictionMajorPass": null,
+        //           "restrictionMinor": null,
+        //           "restrictionMinorPass": null,
+        //           "concurrentCourses": [],
+        //           "timeLocations": [
+        //             {
+        //               "room": "1231",
+        //               "building": "HSSB",
+        //               "roomCapacity": "26",
+        //               "days": "    F  ",
+        //               "beginTime": "10:00",
+        //               "endTime": "10:50"
+        //             }
+        //           ],
+        //           "instructors": [
+        //             {
+        //               "instructor": "CHEN ZHUOTONG",
+        //               "functionCode": "Teaching but not in charge"
+        //             }
+        //           ]
+        //         }
+        //       ],
+        //       "generalEducation": [],
+        //       "finalExam": null
+        //     },
+
+        //   ]);
+
+        // const courses = {
+        //     id: 17,
+        //     psId: 1,
+        //     enrollCd: "12815",
+        // };
+
+        // axiosMock.onPost("/api/courses/post").reply( 200, courses );
+
+
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <PersonalSchedulesDetailsPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+        await waitFor(()=>{
+             expect(screen.getByText("PersonalSchedules Details")).toBeInTheDocument();
+        });
+        await waitFor(()=>{
+            expect(screen.getByTestId("PersonalSchedulesTable-cell-row-0-col-id")).toHaveTextContent("17");
+       });
+       
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-description`)).toHaveTextContent("My Winter Courses");
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-name`)).toHaveTextContent("CS156");
+
+        
+        // PersonalSectionsTable
+        await waitFor(() =>{
+        expect(screen.getByTestId(`${sectionsTestId}-cell-row-0-col-courseId`)).toHaveTextContent("ECE 15");
+        });
     });
 
 });

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesDetailsPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesDetailsPage.test.js
@@ -133,26 +133,6 @@ describe("PersonalSchedulesDetailsPage tests", () => {
               
         });
 
-        // add ECE 15A (enrollCd 12815 for W22)
-        // axiosMock.onPost('/api/courses/post',{params:{enrollCd:'12815',psId:'1'}}).reply(200, {
-        //     "id": 17,
-        //     "user": {
-        //       "id": 1,
-        //       "email": "phtcon@ucsb.edu",
-        //       "googleSub": "115856948234298493496",
-        //       "pictureUrl": "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
-        //       "fullName": "Phill Conrad",
-        //       "givenName": "Phill",
-        //       "familyName": "Conrad",
-        //       "emailVerified": true,
-        //       "locale": "en",
-        //       "hostedDomain": "ucsb.edu",
-        //       "admin": true
-        //     },
-        //     "enrollCd": "12815",
-        //     "psId": 1 
-        // });
-
         axiosMock.onGet('/api/personalSections/all?psId=17').reply(200, [
             {
               "quarter": "20221",
@@ -202,16 +182,6 @@ describe("PersonalSchedulesDetailsPage tests", () => {
 
           ]);
 
-        // const courses = {
-        //     id: 17,
-        //     psId: 1,
-        //     enrollCd: "12815",
-        // };
-
-        // axiosMock.onPost("/api/courses/post").reply( 200, courses );
-
-
-
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
@@ -232,7 +202,7 @@ describe("PersonalSchedulesDetailsPage tests", () => {
         
         // PersonalSectionsTable
         await waitFor(() =>{
-        expect(screen.getByTestId(`${sectionsTestId}-cell-row-0-col-courseId`)).toHaveTextContent("ECE 15");
+            expect(screen.getByTestId(`${sectionsTestId}-cell-row-0-col-courseId`)).toHaveTextContent("ECE 15");
         });
     });
 

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesDetailsPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesDetailsPage.test.js
@@ -134,73 +134,73 @@ describe("PersonalSchedulesDetailsPage tests", () => {
         });
 
         // add ECE 15A (enrollCd 12815 for W22)
-        axiosMock.onPost('/api/courses/post?enrollCd=12815&psId=1').reply(200, {
-            "id": 17,
-            "user": {
-              "id": 1,
-              "email": "phtcon@ucsb.edu",
-              "googleSub": "115856948234298493496",
-              "pictureUrl": "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
-              "fullName": "Phill Conrad",
-              "givenName": "Phill",
-              "familyName": "Conrad",
-              "emailVerified": true,
-              "locale": "en",
-              "hostedDomain": "ucsb.edu",
-              "admin": true
-            },
-            "enrollCd": "12815",
-            "psId": 1 
-        });
-
-        // axiosMock.onGet('/api/personalSections/all').reply(200, [
-        //     {
-        //       "quarter": "20221",
-        //       "courseId": "ECE      15A ",
-        //       "title": "FUND OF LOGIC DES",
-        //       "description": "Boolean algebra, logic of propositions, minterm and maxterm   expansions, Karnaugh maps, Quine-McCluskey method, melti-level circuits, combinational   circuit design and simulation, multiplexers, decoders, programmable logic   devices.",
-        //       "classSections": [
-        //         {
-        //           "enrollCode": "12815",
-        //           "section": "0107",
-        //           "session": null,
-        //           "classClosed": null,
-        //           "courseCancelled": null,
-        //           "gradingOptionCode": null,
-        //           "enrolledTotal": 23,
-        //           "maxEnroll": 23,
-        //           "secondaryStatus": null,
-        //           "departmentApprovalRequired": false,
-        //           "instructorApprovalRequired": false,
-        //           "restrictionLevel": null,
-        //           "restrictionMajor": "+EE   +ECE  +CMPEN+PRCME",
-        //           "restrictionMajorPass": null,
-        //           "restrictionMinor": null,
-        //           "restrictionMinorPass": null,
-        //           "concurrentCourses": [],
-        //           "timeLocations": [
-        //             {
-        //               "room": "1231",
-        //               "building": "HSSB",
-        //               "roomCapacity": "26",
-        //               "days": "    F  ",
-        //               "beginTime": "10:00",
-        //               "endTime": "10:50"
-        //             }
-        //           ],
-        //           "instructors": [
-        //             {
-        //               "instructor": "CHEN ZHUOTONG",
-        //               "functionCode": "Teaching but not in charge"
-        //             }
-        //           ]
-        //         }
-        //       ],
-        //       "generalEducation": [],
-        //       "finalExam": null
+        // axiosMock.onPost('/api/courses/post',{params:{enrollCd:'12815',psId:'1'}}).reply(200, {
+        //     "id": 17,
+        //     "user": {
+        //       "id": 1,
+        //       "email": "phtcon@ucsb.edu",
+        //       "googleSub": "115856948234298493496",
+        //       "pictureUrl": "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
+        //       "fullName": "Phill Conrad",
+        //       "givenName": "Phill",
+        //       "familyName": "Conrad",
+        //       "emailVerified": true,
+        //       "locale": "en",
+        //       "hostedDomain": "ucsb.edu",
+        //       "admin": true
         //     },
+        //     "enrollCd": "12815",
+        //     "psId": 1 
+        // });
 
-        //   ]);
+        axiosMock.onGet('/api/personalSections/all?psId=17').reply(200, [
+            {
+              "quarter": "20221",
+              "courseId": "ECE      15A ",
+              "title": "FUND OF LOGIC DES",
+              "description": "Boolean algebra, logic of propositions, minterm and maxterm   expansions, Karnaugh maps, Quine-McCluskey method, melti-level circuits, combinational   circuit design and simulation, multiplexers, decoders, programmable logic   devices.",
+              "classSections": [
+                {
+                  "enrollCode": "12815",
+                  "section": "0107",
+                  "session": null,
+                  "classClosed": null,
+                  "courseCancelled": null,
+                  "gradingOptionCode": null,
+                  "enrolledTotal": 23,
+                  "maxEnroll": 23,
+                  "secondaryStatus": null,
+                  "departmentApprovalRequired": false,
+                  "instructorApprovalRequired": false,
+                  "restrictionLevel": null,
+                  "restrictionMajor": "+EE   +ECE  +CMPEN+PRCME",
+                  "restrictionMajorPass": null,
+                  "restrictionMinor": null,
+                  "restrictionMinorPass": null,
+                  "concurrentCourses": [],
+                  "timeLocations": [
+                    {
+                      "room": "1231",
+                      "building": "HSSB",
+                      "roomCapacity": "26",
+                      "days": "    F  ",
+                      "beginTime": "10:00",
+                      "endTime": "10:50"
+                    }
+                  ],
+                  "instructors": [
+                    {
+                      "instructor": "CHEN ZHUOTONG",
+                      "functionCode": "Teaching but not in charge"
+                    }
+                  ]
+                }
+              ],
+              "generalEducation": [],
+              "finalExam": null
+            },
+
+          ]);
 
         // const courses = {
         //     id: 17,


### PR DESCRIPTION
## Overview

In this PR, we add ```PersonalSectionsTable``` into ```PersonalScheduleDetailsPage```. The data is populated with the ```/api/personalSections/all``` endpoint with a query to the selected schedule's psId.

We also implemented a scraper function for ```PersonalSectionsTable``` to correctly scrape the ```courseId``` from the ```/api/personalSections/``` endpoint when courseId's either have:

- A suffix: ```"courseId": "ECE       153B -1"```
- No suffix ```"courseId": "ECE       153B  "```

## Details/How to Test

After making a Personal Schedule with a selected quarter, you will find a page similar to this in the Personal Schedules / List menu:

![image](https://user-images.githubusercontent.com/75236585/204735608-bc28701a-cee3-4447-8723-06db3ecb0905.png)

Clicking on details, you'll see an empty ```PersonalSectionsTable``` like this if there aren't any added sections yet:

![image](https://user-images.githubusercontent.com/75236585/204735919-084537cd-33f7-4a7e-858e-63be416c231e.png)

To populate this table, we need to add a course. We can do this by going to the PSCourse / Create form which uses the ```/api/courses/post``` endpoint:

![image](https://user-images.githubusercontent.com/75236585/204736568-78dec534-a7b3-451f-b70a-17a7206d32d4.png)

In order to have a valid entry, you must enter a valid enroll code corresponding to the quarter the Personal Schedules is set up for. For ease of testing, here are enroll codes for both W22 and S22:

- W22 ECE 15A: ```12815```
- S22 ECE 139: ```12773```

Going back to the Personal Schedules Details page, you will now see your added section for your class:

![image](https://user-images.githubusercontent.com/75236585/204737502-bf98ae82-066c-4522-a66f-3cec09748e1e.png)

We have implemented tests which results in 100% line coverage and 100% mutations killed for our corresponding changes to ```PersonalSchedulesDetailsPage``` and ```PersonalSectionsTable```

Closes #38 
