### PR TITLE
DC - FRONTEND: Personal Schedule names should be unique when taken together with the quarter

### DIFF
--- a/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesCreatePage.js
+++ b/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesCreatePage.js
@@ -20,9 +20,19 @@ export default function PersonalSchedulesCreatePage() {
     toast(`New personalSchedule Created - id: ${personalSchedule.id} name: ${personalSchedule.name}`);
   }
 
+  const onError = (error) => {
+    if (error.response.data.type === "NameAndQuarterExistsException") {
+      toast(error.response.data.message);
+    }
+    else {            
+      const errorMessage = `Error communicating with backend via ${error.response.config.method} on ${error.response.config.url}`;
+      toast(errorMessage);
+    }
+  }
+
   const mutation = useBackendMutation(
     objectToAxiosParams,
-     { onSuccess }, 
+     { onSuccess, onError }, 
      // Stryker disable next-line all : hard to set up test for caching
      ["/api/personalschedules/all"]
      );

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesCreatePage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesCreatePage.test.js
@@ -123,15 +123,12 @@ describe("PersonalSchedulesCreatePage tests", () => {
         
         const nameField = screen.getByTestId("PersonalScheduleForm-name");
         const descriptionField = screen.getByTestId("PersonalScheduleForm-description");
-        //const quarterField = document.querySelector("#PersonalScheduleForm-quarter");
         const quarterField = document.querySelector("#PersonalScheduleForm-quarter");
-        //const selectQuarter = getByLabelText("Quarter")
         const submitButton = screen.getByTestId("PersonalScheduleForm-submit");
 
         fireEvent.change(nameField, { target: { value: 'SampName' } });
         fireEvent.change(descriptionField, { target: { value: 'desc' } });
         fireEvent.change(quarterField, { target: { value: '20222' } });
-        //userEvent.selectOptions(selectQuarter, "20124");
 
         expect(submitButton).toBeInTheDocument();
 
@@ -167,15 +164,12 @@ describe("PersonalSchedulesCreatePage tests", () => {
         
         const nameField = screen.getByTestId("PersonalScheduleForm-name");
         const descriptionField = screen.getByTestId("PersonalScheduleForm-description");
-        //const quarterField = document.querySelector("#PersonalScheduleForm-quarter");
         const quarterField = document.querySelector("#PersonalScheduleForm-quarter");
-        //const selectQuarter = getByLabelText("Quarter")
         const submitButton = screen.getByTestId("PersonalScheduleForm-submit");
 
         fireEvent.change(nameField, { target: { value: 'SampName' } });
         fireEvent.change(descriptionField, { target: { value: 'desc' } });
         fireEvent.change(quarterField, { target: { value: '20222' } });
-        //userEvent.selectOptions(selectQuarter, "20124");
 
         expect(submitButton).toBeInTheDocument();
 

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesCreatePage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesCreatePage.test.js
@@ -104,5 +104,92 @@ describe("PersonalSchedulesCreatePage tests", () => {
         expect(mockNavigate).toBeCalledWith({ "to": "/personalschedules/list" });
     });
 
+    test("when you fill in a duplicate name and quarter, it shows a popup warning", async () => {
+
+        const queryClient = new QueryClient();
+        const expectedResponse = { type: "NameAndQuarterExistsException", message: "Name and Quarter are invalid (There already exists a schedule named SampName during 20222)" };
+
+        axiosMock.onPost("/api/personalschedules/post").reply( 400, expectedResponse );
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <PersonalSchedulesCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByTestId("PersonalScheduleForm-name")).toBeInTheDocument();
+        
+        const nameField = screen.getByTestId("PersonalScheduleForm-name");
+        const descriptionField = screen.getByTestId("PersonalScheduleForm-description");
+        //const quarterField = document.querySelector("#PersonalScheduleForm-quarter");
+        const quarterField = document.querySelector("#PersonalScheduleForm-quarter");
+        //const selectQuarter = getByLabelText("Quarter")
+        const submitButton = screen.getByTestId("PersonalScheduleForm-submit");
+
+        fireEvent.change(nameField, { target: { value: 'SampName' } });
+        fireEvent.change(descriptionField, { target: { value: 'desc' } });
+        fireEvent.change(quarterField, { target: { value: '20222' } });
+        //userEvent.selectOptions(selectQuarter, "20124");
+
+        expect(submitButton).toBeInTheDocument();
+
+        fireEvent.click(submitButton);
+
+        expect(axiosMock.history.post.length).toBe(0);
+
+        await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+
+        expect(quarterField).toHaveValue("20222");
+
+        expect(mockToast).toHaveBeenCalledTimes(1);
+        expect(mockToast).toBeCalledWith("Name and Quarter are invalid (There already exists a schedule named SampName during 20222)");
+    });
+
+    test("when you get some generic error, it shows a popup warning", async () => {
+
+        const queryClient = new QueryClient();
+        const expectedResponse = { config: { method: "post", url: "/api/personalschedules/post" } };
+
+        axiosMock.onPost("/api/personalschedules/post").reply( 400, expectedResponse );
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <PersonalSchedulesCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByTestId("PersonalScheduleForm-name")).toBeInTheDocument();
+        
+        const nameField = screen.getByTestId("PersonalScheduleForm-name");
+        const descriptionField = screen.getByTestId("PersonalScheduleForm-description");
+        //const quarterField = document.querySelector("#PersonalScheduleForm-quarter");
+        const quarterField = document.querySelector("#PersonalScheduleForm-quarter");
+        //const selectQuarter = getByLabelText("Quarter")
+        const submitButton = screen.getByTestId("PersonalScheduleForm-submit");
+
+        fireEvent.change(nameField, { target: { value: 'SampName' } });
+        fireEvent.change(descriptionField, { target: { value: 'desc' } });
+        fireEvent.change(quarterField, { target: { value: '20222' } });
+        //userEvent.selectOptions(selectQuarter, "20124");
+
+        expect(submitButton).toBeInTheDocument();
+
+        fireEvent.click(submitButton);
+
+        expect(axiosMock.history.post.length).toBe(0);
+
+        await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+
+        expect(quarterField).toHaveValue("20222");
+
+        expect(mockToast).toHaveBeenCalledTimes(1);
+        expect(mockToast).toBeCalledWith("Error communicating with backend via post on /api/personalschedules/post");
+    });
 
 });


### PR DESCRIPTION
<h1>Overview</h1>
In this PR, the changes made make it so that when a duplicate name and quarter personal schedule is attempted to be created, the frontend will now respond and tell the user that this is not allowed. This issue goes hand in hand with the backend issue of the same topic.

<h1>Details</h1>

If a duplicate name and quarter personal schedule is attempted to be created, a pop up shows up saying that the quarter and name are invalid. This can be tested using the unit tests and by going onto Heroku and attempting to create a personal schedule with the same name and quarter as another schedule. An example of this can be seen down below:

![Screen Shot 2022-11-30 at 12 18 12 PM](https://user-images.githubusercontent.com/77405374/204899746-fc360e91-4237-4e5f-ac3c-96e165fee2dc.png)


![Screen Shot 2022-11-30 at 12 18 25 PM](https://user-images.githubusercontent.com/77405374/204899737-796d4d58-e142-40af-88fe-49e75ed0aae7.png)

Closes #5 