### PR TITLE
Add Percentage in Enrolled Column

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,9 @@
 frontend/.stryker-tmp
 frontend/reports
 frontend/strykerTmp
-
+/.stryker-tmp
 # Don't check in a built storybook #
-
+.history
 frontend/storybook-static
 
 # If a package-lock.json shows up in top level dir, don't store it in github

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.DS_Store
+
 ## emacs ##
 *~
 
@@ -10,6 +12,7 @@ frontend/reports
 .history
 frontend/strykerTmp
 /.stryker-tmp
+
 
 # Don't check in a built storybook #
 .history

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,25 +1,57 @@
-# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+## emacs ##
+*~
 
-# dependencies
-/node_modules
-/.pnp
-.pnp.js
+# Stryker reports
 
-# testing
-/coverage
+frontend/.stryker-tmp
+/.stryker-tmp
+frontend/reports
 
-# production
-/build
+.history
+frontend/strykerTmp
+/.stryker-tmp
 
-# misc
-.DS_Store
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+# Don't check in a built storybook #
+.history
+frontend/storybook-static
+.history
+# If a package-lock.json shows up in top level dir, don't store it in github
+# Only keep the one under frontend/
 
-strykerTmp
+package-lock.json
+!frontend/package-lock.json
 
-npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
+# Maven
+
+/target
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/
+
+### Local Configuration ###
+.env

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,57 +1,25 @@
-## emacs ##
-*~
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
-# Stryker reports
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
 
-frontend/.stryker-tmp
-/.stryker-tmp
-frontend/reports
+# testing
+/coverage
 
-.history
-frontend/strykerTmp
-/.stryker-tmp
+# production
+/build
 
-# Don't check in a built storybook #
-.history
-frontend/storybook-static
-.history
-# If a package-lock.json shows up in top level dir, don't store it in github
-# Only keep the one under frontend/
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
 
-package-lock.json
-!frontend/package-lock.json
+strykerTmp
 
-# Maven
-
-/target
-
-### STS ###
-.apt_generated
-.classpath
-.factorypath
-.project
-.settings
-.springBeans
-.sts4-cache
-
-### IntelliJ IDEA ###
-.idea
-*.iws
-*.iml
-*.ipr
-
-### NetBeans ###
-/nbproject/private/
-/nbbuild/
-/dist/
-/nbdist/
-/.nb-gradle/
-build/
-!**/src/main/**/build/
-!**/src/test/**/build/
-
-### VS Code ###
-.vscode/
-
-### Local Configuration ###
-.env
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/frontend/src/main/components/Sections/SectionsTable.js
+++ b/frontend/src/main/components/Sections/SectionsTable.js
@@ -1,8 +1,8 @@
 import SectionsTableBase from "main/components/SectionsTableBase";
 
 import { yyyyqToQyy } from "main/utils/quarterUtilities.js";
-import { convertToFraction, formatDays, formatInstructors, formatLocation, formatTime, isSection } from "main/utils/sectionUtils.js";
-import { boldIfNotSection, fraction_w_percent } from "main/utils/sectionUtils";
+import { _convertToFraction, formatDays, formatInstructors, formatLocation, formatTime, isSection } from "main/utils/sectionUtils.js";
+import { _boldIfNotSection, fraction_w_percent } from "main/utils/sectionUtils";
 
 
 function getFirstVal(values) {

--- a/frontend/src/main/components/Sections/SectionsTable.js
+++ b/frontend/src/main/components/Sections/SectionsTable.js
@@ -2,9 +2,8 @@ import SectionsTableBase from "main/components/SectionsTableBase";
 
 import { yyyyqToQyy } from "main/utils/quarterUtilities.js";
 import { _convertToFraction, formatDays, formatInstructors, formatLocation, formatTime, isSection } from "main/utils/sectionUtils.js";
-import { _boldIfNotSection, fraction_w_percent } from "main/utils/sectionUtils";
+import { boldIfNotSection, fraction_w_percent } from "main/utils/sectionUtils";
 
-import { boldIfNotSection } from "main/utils/sectionUtils";
 
 
 function getFirstVal(values) {

--- a/frontend/src/main/components/Sections/SectionsTable.js
+++ b/frontend/src/main/components/Sections/SectionsTable.js
@@ -2,6 +2,7 @@ import SectionsTableBase from "main/components/SectionsTableBase";
 
 import { yyyyqToQyy } from "main/utils/quarterUtilities.js";
 import { convertToFraction, formatDays, formatInstructors, formatLocation, formatTime, isSection } from "main/utils/sectionUtils.js";
+import { boldIfNotSection, fraction_w_percent } from "main/utils/sectionUtils";
 
 
 function getFirstVal(values) {
@@ -46,7 +47,7 @@ export default function SectionsTable({ sections }) {
         },
         {
             Header: 'Enrolled',
-            accessor: (row) => convertToFraction(row.section.enrolledTotal, row.section.maxEnroll),
+            accessor: (row, _rowIndex) => fraction_w_percent(row.section.enrolledTotal, row.section.maxEnroll),
             disableGroupBy: true,
             id: 'enrolled',
 

--- a/frontend/src/main/utils/sectionUtils.js
+++ b/frontend/src/main/utils/sectionUtils.js
@@ -4,6 +4,17 @@ export const convertToFraction = (en1, en2) => {
     return (en1 != null && en2 != null) ? `${en1}/${en2}` : "";
 }
 
+export const fraction_w_percent = (num, denom) => {
+    if ((num === null) || (denom === null)) {
+        if (denom !== null) {
+            return denom;
+        }
+        return '';
+    }
+    let percent = (parseInt(num) / parseInt(denom)) * 100;
+    percent = percent.toFixed();
+    return `${num}/${denom} (${percent}%)`;
+}
 
 // Takes a time location array and returns the locations
 export const formatLocation = (timeLocationArray) => {

--- a/frontend/src/tests/components/Sections/SectionsTable.test.js
+++ b/frontend/src/tests/components/Sections/SectionsTable.test.js
@@ -99,7 +99,7 @@ describe("Section tests", () => {
       expect(screen.getByTestId(`${testId}-cell-row-0-col-quarter`)).toHaveTextContent("W22");
       expect(screen.getByTestId(`${testId}-cell-row-0-col-time`)).toHaveTextContent("3:00 PM - 3:50 PM");
       expect(screen.getByTestId(`${testId}-cell-row-0-col-days`)).toHaveTextContent("M");
-      expect(screen.getByTestId(`${testId}-cell-row-0-col-enrolled`)).toHaveTextContent("84/100");
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-enrolled`)).toHaveTextContent("84/100 (84%)");
       expect(screen.getByTestId(`${testId}-cell-row-0-col-location`)).toHaveTextContent("BUCHN 1930");
       expect(screen.getByTestId(`${testId}-cell-row-0-col-instructor`)).toHaveTextContent("WANG L C");
       expect(screen.getByTestId(`${testId}-cell-row-0-col-section.enrollCode`)).toHaveTextContent("12583");
@@ -142,8 +142,8 @@ describe("Section tests", () => {
       const expandRow = screen.getByTestId(`${testId}-cell-row-1-col-courseInfo.courseId-expand-symbols`)
       fireEvent.click(expandRow);
 
-      expect(screen.getByTestId(`${testId}-cell-row-1-col-enrolled`)).toHaveTextContent("84/80");
-      expect(screen.getByTestId(`${testId}-cell-row-2-col-enrolled`)).toHaveTextContent("21/21");
+      expect(screen.getByTestId(`${testId}-cell-row-1-col-enrolled`)).toHaveTextContent("84/80 (105%)");
+      expect(screen.getByTestId(`${testId}-cell-row-2-col-enrolled`)).toHaveTextContent("21/21 (100%)");
   });
 
 

--- a/frontend/src/tests/utils/sectionUtils.test.js
+++ b/frontend/src/tests/utils/sectionUtils.test.js
@@ -1,4 +1,5 @@
 import {convertToFraction, formatLocation, isSection, formatDays, formatTime, formatInstructors} from "main/utils/sectionUtils"
+import { boldIfNotSection, fraction_w_percent } from "main/utils/sectionUtils";
 
 const testTimeLocations = [
     {
@@ -50,8 +51,20 @@ const testInstructors = [
 ]
 
 describe ("section utils tests", () => {
+
+    test("fraction with percent test", () => {
+        expect(fraction_w_percent(null, null)).toBe("");
+        expect(fraction_w_percent(null, "44")).toBe("44");
+        expect(fraction_w_percent("10", "100")).toBe("10/100 (10%)");
+        expect(fraction_w_percent('2', null)).toBe("");
+    });
+
     test("convertToFraction one null test 1" , () => {
         expect(convertToFraction(null, "100")).toBe("");
+    }); 
+
+    test("convertToFraction one null test 3" , () => {
+        expect(convertToFraction("10", "100")).toBe("10/100");
     }); 
 
     test("convertToFraction one null test 2" , () => {


### PR DESCRIPTION
In this PR, we add the fraction for the enrolled column. 
We write a new function that takes the numerator (enrolled) and denominator (maximum) and return the percentage to the enrolled column. 
In this case, the enrollment column will display in a fraction of the total enrolled over the max seats available and give a specific percentage. Some rows will return empty since the enrolled seats or the maximum seats are invalid. It passed all the tests.

Here is the deployment on QA:

<img width="1427" alt="image" src="https://user-images.githubusercontent.com/64247457/204934008-43e588cc-bd3f-40bf-a316-6ee2b8147805.png">

Close #56 