### PR TITLE
Ps dropdown patch 1

### DIFF
--- a/frontend/src/main/components/Courses/CourseForm.js
+++ b/frontend/src/main/components/Courses/CourseForm.js
@@ -6,6 +6,9 @@ import { useNavigate } from 'react-router-dom'
 import SinglePersonalScheduleDropdown from "../PersonalSchedules/SinglePersonalScheduleDropdown";
 import { useBackend } from "main/utils/useBackend";
 
+let initialState = true;
+let initialRender = true;
+
 function CourseForm({ initialCourse, submitAction, buttonLabel = "Create" }) {
 
     const { data: personalSchedules, error: _error, status: _status } =
@@ -15,7 +18,23 @@ function CourseForm({ initialCourse, submitAction, buttonLabel = "Create" }) {
         []
     );
 
-    const localPersonalSchedule = localStorage.getItem("CourseForm-psId");
+    if(initialState && personalSchedules[0] != null){
+        setTimeout(() => {  
+            localStorage.setItem("CourseForm-psId", personalSchedules[0].id);
+            initialState = false;
+        }, 200);
+    }
+
+    let localPersonalSchedule;
+    if(initialRender){
+        setTimeout(() => {  
+            localPersonalSchedule = localStorage.getItem("CourseForm-psId");
+            initialRender = false;
+        }, 250);
+    }
+    else{
+        localPersonalSchedule = localStorage.getItem("CourseForm-psId");
+    }
 
     const [personalSchedule, setPersonalSchedule] = useState(localPersonalSchedule || {});
 
@@ -67,7 +86,7 @@ function CourseForm({ initialCourse, submitAction, buttonLabel = "Create" }) {
 
             <Form.Group className="mb-3" data-testid="CourseForm-psId">
                 <SinglePersonalScheduleDropdown
-                    personalSchedule={personalSchedule.id}
+                    personalSchedule={personalSchedule}
                     setPersonalSchedule={setPersonalSchedule} 
                     controlId={"CourseForm-psId"}
                     label={"Personal Schedule"}

--- a/frontend/src/main/components/Courses/CourseForm.js
+++ b/frontend/src/main/components/Courses/CourseForm.js
@@ -86,7 +86,7 @@ function CourseForm({ initialCourse, submitAction, buttonLabel = "Create" }) {
 
             <Form.Group className="mb-3" data-testid="CourseForm-psId">
                 <SinglePersonalScheduleDropdown
-                    personalSchedule={personalSchedule}
+                    personalSchedule={personalSchedule.id}
                     setPersonalSchedule={setPersonalSchedule} 
                     controlId={"CourseForm-psId"}
                     label={"Personal Schedule"}

--- a/frontend/src/main/components/PersonalSchedules/SinglePersonalScheduleDropdown.js
+++ b/frontend/src/main/components/PersonalSchedules/SinglePersonalScheduleDropdown.js
@@ -2,6 +2,8 @@ import { yyyyqToQyy } from "main/utils/quarterUtilities";
 import React, { useState } from "react";
 import { Form } from "react-bootstrap";
 
+let initialRender = true;
+
 const SinglePersonalScheduleDropdown = ({
   personalSchedules,
   personalSchedule,
@@ -10,7 +12,17 @@ const SinglePersonalScheduleDropdown = ({
   onChange = null,
   label = "Personal Schedule",
 }) => {
-  const localSearchPersonalSchedule = localStorage.getItem(controlId);
+
+  let localSearchPersonalSchedule;
+  if(initialRender){
+    setTimeout(() => {  
+      localSearchPersonalSchedule = localStorage.getItem(controlId);
+      initialRender = false;
+    }, 300);
+  }
+  else{
+    localSearchPersonalSchedule = localStorage.getItem(controlId);
+  }
 
   const [personalScheduleState, setPersonalScheduleState] = useState(
     // Stryker disable next-line all : not sure how to test/mock local storage

--- a/frontend/src/tests/components/Courses/CourseForm.test.js
+++ b/frontend/src/tests/components/Courses/CourseForm.test.js
@@ -79,34 +79,34 @@ describe("CourseForm tests", () => {
         
     });
 
-    // test("No Error messages on good input", async () => {
-    //     const mockSubmitAction = jest.fn();
+    test("No Error messages on good input", async () => {
+        const mockSubmitAction = jest.fn();
 
-    //     render(
-    //         <QueryClientProvider client={queryClient}>
-    //             <Router>
-    //                 <CourseForm submitAction={mockSubmitAction} />
-    //             </Router>
-    //         </QueryClientProvider>
-    //     );
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <CourseForm submitAction={mockSubmitAction} />
+                </Router>
+            </QueryClientProvider>
+        );
 
-    //     expect(await screen.findByTestId("CourseForm-psId")).toBeInTheDocument();
+        expect(await screen.findByTestId("CourseForm-psId")).toBeInTheDocument();
 
-    //     const selectPsId = screen.getByLabelText("Personal Schedule");
-    //     userEvent.selectOptions(selectPsId, "13");
-    //     const enrollCd = screen.getByTestId("CourseForm-enrollCd");
-    //     const submitButton = screen.getByTestId("CourseForm-submit");
+        const selectPsId = screen.getByLabelText("Personal Schedule");
+        userEvent.selectOptions(selectPsId, "13");
+        const enrollCd = screen.getByTestId("CourseForm-enrollCd");
+        const submitButton = screen.getByTestId("CourseForm-submit");
 
-    //     fireEvent.change(selectPsId, { target: { value: '13' } });
-    //     fireEvent.change(enrollCd, { target: { value: '20124' } });
-    //     fireEvent.click(submitButton);
+        fireEvent.change(selectPsId, { target: { value: '13' } });
+        fireEvent.change(enrollCd, { target: { value: '20124' } });
+        fireEvent.click(submitButton);
 
-    //     await waitFor(() => expect(mockSubmitAction).toHaveBeenCalled());
+        await waitFor(() => expect(mockSubmitAction).toHaveBeenCalled());
 
-    //     expect(screen.queryByText(/Enroll Code is required./)).not.toBeInTheDocument();
-    //     expect(selectPsId.value).toBe("13");
-    //     expect(enrollCd).toHaveValue("20124");
-    // });
+        expect(screen.queryByText(/Enroll Code is required./)).not.toBeInTheDocument();
+        expect(selectPsId.value).toBe("13");
+        expect(enrollCd).toHaveValue("20124");
+    });
 
     test("that navigate(-1) is called when Cancel is clicked", async () => {
         render(


### PR DESCRIPTION
Fixes bug associated with dropdown menu for Personal Schedule in PSCourses create page. 

Bug occurs when only one Personal Schedule is in the dropdown list and the state of the list does not change from null initially since the onChange event can not occur with only one option in the list. Bug also occurs when previously selected Personal Schedule is deleted from the Personal Schedules which maintains the previous state until there is an onChange event, this results in PScourse creations being called with a deleted psId. 

A workaround is found by initializing state of the dropdown list to the first element of the personalSchedules list on the first render. This workaround currently requires a setTimeout for the call to the API to be processed in time for the first render, if there is no setTimeout specified the page does not render. 

There are known problems with mutation testing but in testing on localhost for a variety of situations, the dropdown menu behavior now works as intended without any bugs. Unsure if conventions would allow for localPersonalSchedule to be changed from const to a variable and the use of variables outside of the function for initial render tracking purposes.

Please note this is an unpolished PR but its main purpose is to address and make future contributors aware of the cause for potential bugs in the PSDropdown component that may not be obvious for other dropdown components such as the Quarter dropdown or Subject Dropdown which have states that generally do not change in between renders.